### PR TITLE
feat/desktop-release-pipeline - Add desktop release support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,9 +9,8 @@ on:
 
 jobs:
   web:
-    uses: ./.github/workflows/web.yml
+    uses: ./.github/workflows/release_web.yml
 
-  # NOTE: To be implemented at a later date
-  # desktop:
-  #   uses: ./.github/workflows/desktop.yml
-  #   secrets: inherit
+  desktop:
+    uses: ./.github/workflows/release_desktop.yml
+    secrets: inherit

--- a/.github/workflows/release_desktop.yml
+++ b/.github/workflows/release_desktop.yml
@@ -271,7 +271,7 @@ jobs:
     runs-on: ubuntu-24.04
     needs: [build, bundle_macos, bundle_linux, sign_win]
     env:
-      VERSION: ${{ needs.build.outputs.NODE_VERSION }}
+      VERSION: ${{ needs.build.outputs.BUILD_VERSION }}
     steps:
       - name: Get artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/release_desktop.yml
+++ b/.github/workflows/release_desktop.yml
@@ -241,7 +241,7 @@ jobs:
             --storetype "${{ secrets.WIN_STORE_TYPE }}" \
             --storepass "${{ secrets.WIN_STORE_SECRET }}" \
             --tsaurl "http://timestamp.sectigo.com" \
-            --certfile $TMP_WIN_CERT_PATH \
+            --certfile $TMP_CERT_PATH \
             $BUNDLE_PATH
 
           docker run \
@@ -260,6 +260,8 @@ jobs:
           compression-level: 0
           if-no-files-found: error
           retention-days: 1
+      - name: Cleanup
+        run: rm -rf ./output
 
   release:
     if: github.ref_name == 'master'

--- a/.github/workflows/release_desktop.yml
+++ b/.github/workflows/release_desktop.yml
@@ -38,7 +38,7 @@ jobs:
 
           npm ci
 
-          security -v unlock-keychain -p "${{ secrets.KC_SECRET }}" ~/Library/Keychains/login.keychain-db
+          security -v unlock-keychain -p "${{ secrets.APPLE_KC_SECRET }}" ~/Library/Keychains/login.keychain-db
       - name: Build
         run: npm run build-prod-electron
       - name: Bundle

--- a/.github/workflows/release_desktop.yml
+++ b/.github/workflows/release_desktop.yml
@@ -1,0 +1,135 @@
+name: "Release: Desktop"
+
+on:
+  workflow_call:
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    if: github.ref_name == 'master'
+    runs-on: [self-hosted, build]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch_depth: 1
+      - name: Get Node version
+        run: echo "BUILD_NODE_VER=$(ggrep -o -P -m 1 '(?<=node":\s").*(?=")' package.json)" >> "$GITHUB_ENV"
+      - name: Node setup
+        run: source ~/load_nvm.sh && nvm install ${{ env.BUILD_NODE_VER }}
+      - name: Cache setup
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: npm-${{ hashFiles('package-lock.json') }}
+          restore-keys: npm-
+      - name: Dependency setup
+        run: |
+          TMP_PROV_PROF_PATH=$RUNNER_TEMP/embedded.provisionprofile
+          TMP_WIN_CERT_PATH=$RUNNER_TEMP/cert_win.pem
+
+          echo -n "${{ secrets.APPLE_PROV_PROF_BASE64 }}" | base64 --decode -o $TMP_PROV_PROF_PATH
+          echo -n "${{ secrets.WIN_CERT_BASE64 }}" | base64 --decode -o $TMP_WIN_CERT_PATH
+
+          cp "$TMP_PROV_PROF_PATH" ./embedded.provisionprofile
+          cp "$TMP_WIN_CERT_PATH" ./cert_win.pem
+
+          npm ci && npm install -g electron-builder
+
+          security -v unlock-keychain -p "${{ secrets.KC_SECRET }}" ~/Library/Keychains/login.keychain-db
+      - name: Build
+        run: npm run build-prod-electron
+      - name: Bundle
+        run: |
+          electron-builder --mac --universal --publish never & (
+          electron-builder --win --x64 --publish never &&
+          WIN_BUNDLE_PATH=$(find ./output -name "JUSTIFI-*-*.exe") &&
+          java -jar ~/jsign.jar \
+            --storetype "${{ secrets.WIN_STORE_TYPE }}" \
+            --storepass "${{ secrets.WIN_STORE_SECRET }}" \
+            --tsaurl "http://timestamp.sectigo.com" \
+            --certfile ./cert_win.pem \
+            WIN_BUNDLE_PATH &&
+          OLD_HASH=$(ggrep -o -P -m 1 '(?<=sha512:\s).*' ./output/latest.yml) &&
+          NEW_HASH=$(node ~/gen_hash.js -f $WIN_BUNDLE_PATH) &&
+          docker run -v ./output:/output ubuntu:latest bash -c 'sed "s/$OLD_HASH/$NEW_HASH/g" /output/latest.yml'
+          ) &
+          electron-builder --linux --x64 --publish never
+      - name: Prepare output
+        run: |
+          VERSION=$(ggrep -A3 'version:' ../output/latest-mac.yml | head -n1 | awk '{print $2}')
+          OUTPUT_DIR="$(pwd)/output"
+          echo "BUILD_VERSION=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "RUNNER_OUTPUT_DIR=$OUTPUT_DIR" >> "$GITHUB_ENV"
+      - name: Upload notarization artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: notarization-artifact
+          path: |
+            ${{ env.RUNNER_OUTPUT_DIR }}/*.dmg
+          compression-level: 1
+          if-no-files-found: error
+          retention-days: 1
+      - name: Upload winux artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: winux-release-artifact
+          path: |
+            ${{ env.RUNNER_OUTPUT_DIR }}/*
+            !${{ env.RUNNER_OUTPUT_DIR }}/*-unpacked
+            !${{ env.RUNNER_OUTPUT_DIR }}/*-universal
+            !${{ env.RUNNER_OUTPUT_DIR }}/*.dmg
+            !${{ env.RUNNER_OUTPUT_DIR }}/builder*
+          compression-level: 1
+          if-no-files-found: error
+          retention-days: 1
+    outputs:
+            BUILD_VERSION: ${{ steps.output.outputs.BUILD_VERSION }}
+
+  notarization:
+    if: github.ref_name == 'master'
+    runs-on: macos-13
+    needs: [build]
+    steps:
+      - name: Get artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: notarization-artifact
+      - name: Notarize
+        run: |
+          xcrun notarytool submit --wait --apple-id "${{ secrets.APPLE_ID }}" --password "${{ secrets.APPLE_APP_SECRET }}" --team-id "${{ secrets.APPLE_TEAM_ID }}" $(find ./ -name "JUSTIFI-*-*.dmg") &&
+          sleep 60 &&
+          xcrun stapler staple $(find ./ -name "JUSTIFI-*-*.dmg")
+      - name: Upload notarized artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-release-artifact
+          path: ./*.dmg
+          compression-level: 1
+          if-no-files-found: error
+          retention-days: 1
+
+  release:
+    if: github.ref_name == 'master'
+    runs-on: ubuntu-22.04
+    needs: [build,notarization]
+    env:
+      VERSION: ${{ needs.build.outputs.BUILD_VERSION }}
+    steps:
+      - name: Get artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: *-release-artifact
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        # if: startsWith(github.ref, 'refs/tags/') # Uncomment if enabling tag gating
+        with:
+          name: JUSTIFI v${{ env.VERSION }}
+          tag_name: v${{ env.VERSION }}
+          draft: true # Comment out if enabling tag gating and publishing via action
+          generate_release_notes: false
+          files: |
+            macos-release-artifact/*
+            winux-release-artifact/*

--- a/.github/workflows/release_desktop.yml
+++ b/.github/workflows/release_desktop.yml
@@ -233,7 +233,7 @@ jobs:
       - name: Codesign
         run: |
           TMP_CERT_PATH="$RUNNER_TEMP/cert.pem"
-          BUNDLE_PATH=$(find ./ -name "JUSTIFI-Setup-*.exe")
+          BUNDLE_PATH=$(find . -name "JUSTIFI-Setup-*.exe")
 
           echo -n "${{ secrets.WIN_CERT_BASE64 }}" | base64 --decode -o $TMP_CERT_PATH
 
@@ -244,12 +244,12 @@ jobs:
             --certfile $TMP_CERT_PATH \
             $BUNDLE_PATH
 
-          _OLD_HASH=$(ggrep -o -P -m 1 '(?<=sha512:\s).*' ./output/latest.yml)
-          _NEW_HASH=$(node ~/gen_hash.js -f $BUNDLE_PATH)
+          OLD_HASH=$(ggrep -o -P -m 1 '(?<=sha512:\s).*' ./output/latest.yml)
+          NEW_HASH=$(node ~/gen_hash.js -f "$BUNDLE_PATH")
 
           docker run \
-            --env OLD_HASH=$_OLD_HASH \
-            --env NEW_HASH=$_NEW_HASH \
+            --env OLD_HASH="$OLD_HASH" \
+            --env NEW_HASH="$NEW_HASH" \
             -v ./output:/output \
             ubuntu:latest \
             sed -i "s|$OLD_HASH|$NEW_HASH|g" /output/latest.yml
@@ -258,8 +258,8 @@ jobs:
         with:
           name: release-win-artifact
           path: |
-            ./*.exe
-            ./latest.yml
+            output/*.exe
+            output/latest.yml
           compression-level: 0
           if-no-files-found: error
           retention-days: 1

--- a/.github/workflows/release_desktop.yml
+++ b/.github/workflows/release_desktop.yml
@@ -28,7 +28,7 @@ jobs:
           key: npm-${{ hashFiles('package-lock.json') }}
           restore-keys: npm-
       - name: Setup dependencies
-        run: npm ci
+        run: npm install
       - name: Build
         run: npm run build-prod-electron
       - name: Upload artifact
@@ -65,7 +65,7 @@ jobs:
           key: npm-${{ hashFiles('package-lock.json') }}
           restore-keys: npm-
       - name: Install dependencies
-        run: npm ci
+        run: npm install
       - name: Codesigning Setup
         env:
           APPLE_CERT_A_BASE64: ${{ secrets.APPLE_CERT_A_BASE64 }}
@@ -148,7 +148,7 @@ jobs:
           key: npm-${{ hashFiles('package-lock.json') }}
           restore-keys: npm-
       - name: Install dependencies
-        run: npm ci
+        run: npm install
       - name: Bundle
         run: |
           npm run dist -- --${{ matrix.OS }} --x64 --publish never

--- a/.github/workflows/release_desktop.yml
+++ b/.github/workflows/release_desktop.yml
@@ -44,8 +44,11 @@ jobs:
       - name: Bundle
         run: |
           npm run dist -- --mac --universal --publish never & (
-            npm run dist -- --win --x64 --publish never &&
-            WIN_BUNDLE_PATH=$(find ./output -name "JUSTIFI-*-*.exe") &&
+            docker run \
+              -v ./:/project \
+              electronuserland/builder:wine \
+              npm run dist -- --win --x64 --publish never &&
+            WIN_BUNDLE_PATH=$(find ./output -name "JUSTIFI-Setup-*.exe") &&
             java -jar ~/jsign.jar \
               --storetype "${{ secrets.WIN_STORE_TYPE }}" \
               --storepass "${{ secrets.WIN_STORE_SECRET }}" \
@@ -54,7 +57,12 @@ jobs:
               $WIN_BUNDLE_PATH &&
             OLD_HASH=$(ggrep -o -P -m 1 '(?<=sha512:\s).*' ./output/latest.yml) &&
             NEW_HASH=$(node ~/gen_hash.js -f $WIN_BUNDLE_PATH) &&
-            docker run -v ./output:/output ubuntu:latest bash -c 'sed "s/$OLD_HASH/$NEW_HASH/g" ./output/latest.yml'
+            docker run \
+              --env OLD_HASH=$OLD_HASH \
+              --env NEW_HASH=$NEW_HASH \
+              -v ./output:/output \
+              ubuntu:latest \
+              sed -i "s|$OLD_HASH|$NEW_HASH|g" /output/latest.yml
           ) &
           npm run dist -- --linux --x64 --publish never
       - name: Prepare output
@@ -103,9 +111,9 @@ jobs:
             --apple-id "${{ secrets.APPLE_ID }}" \
             --password "${{ secrets.APPLE_APP_SECRET }}" \
             --team-id "${{ secrets.APPLE_TEAM_ID }}" \
-            $(find ./ -name "JUSTIFI-*-*.dmg") &&
+            $(find ./ -name "JUSTIFI-*.dmg") &&
           sleep 60 &&
-          xcrun stapler staple $(find ./ -name "JUSTIFI-*-*.dmg")
+          xcrun stapler staple $(find ./ -name "JUSTIFI-*.dmg")
       - name: Upload notarized artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release_desktop.yml
+++ b/.github/workflows/release_desktop.yml
@@ -244,9 +244,12 @@ jobs:
             --certfile $TMP_CERT_PATH \
             $BUNDLE_PATH
 
+          _OLD_HASH=$(ggrep -o -P -m 1 '(?<=sha512:\s).*' ./output/latest.yml)
+          _NEW_HASH=$(node ~/gen_hash.js -f $BUNDLE_PATH)
+
           docker run \
-            --env OLD_HASH=$(ggrep -o -P -m 1 '(?<=sha512:\s).*' ./output/latest.yml) \
-            --env NEW_HASH=$(node ~/gen_hash.js -f $BUNDLE_PATH) \
+            --env OLD_HASH=$_OLD_HASH \
+            --env NEW_HASH=$_NEW_HASH \
             -v ./output:/output \
             ubuntu:latest \
             sed -i "s|$OLD_HASH|$NEW_HASH|g" /output/latest.yml

--- a/.github/workflows/release_desktop.yml
+++ b/.github/workflows/release_desktop.yml
@@ -112,12 +112,7 @@ jobs:
         run: |
           BINARIES=($(find ./output/ -name "JUSTIFI-*-arm64.dmg") $(find ./output/ -name "JUSTIFI-*-x64.dmg"))
           for BINARY in "${BINARIES[@]}"; do
-            xcrun notarytool submit --wait \
-              --apple-id "$APPLE_ID" \
-              --password "$APPLE_APP_SECRET" \
-              --team-id "$APPLE_TEAM_ID" \
-              $BINARY &&
-            sleep 30 &&
+            xcrun notarytool submit --wait --apple-id "$APPLE_ID" --password "$APPLE_APP_SECRET" --team-id "$APPLE_TEAM_ID" $BINARY &&
             xcrun stapler staple $BINARY
           done
       - name: Upload release artifact

--- a/.github/workflows/release_desktop.yml
+++ b/.github/workflows/release_desktop.yml
@@ -15,12 +15,17 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
-      - name: Fetch node version
-        run: echo "BUILD_NODE_VERSION=$(grep -o -P -m 1 '(?<=node":\s").*(?=")' package.json)" >> "$GITHUB_ENV"
+      - name: Setup outputs
+        id: output
+        run: |
+          _NODE_VERSION=$(grep -o -P -m 1 '(?<=node":\s").*(?=")' package.json)
+          _BUILD_VERSION=$(grep '"version"' package.json | head -n1 | sed -E 's/.*"version": *"([^"]+)".*/\1/')
+          echo "NODE_VERSION=$_NODE_VERSION" >> "$GITHUB_OUTPUT"
+          echo "BUILD_VERSION=$_BUILD_VERSION" >> "$GITHUB_OUTPUT"
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ env.BUILD_NODE_VERSION }}
+          node-version: ${{ steps.output.outputs.NODE_VERSION }}
       - name: Setup cache
         uses: actions/cache@v4
         with:
@@ -40,6 +45,9 @@ jobs:
           compression-level: 6
           if-no-files-found: error
           retention-days: 1
+    outputs:
+      NODE_VERSION: ${{ steps.output.outputs.NODE_VERSION }}
+      BUILD_VERSION: ${{ steps.output.outputs.BUILD_VERSION }}
 
   bundle_macos:
     if: github.ref_name == 'master'
@@ -54,12 +62,11 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: build-artifact
-      - name: Fetch node version
-        run: echo "BUILD_NODE_VERSION=$(grep -o -P -m 1 '(?<=node":\s").*(?=")' package.json)" >> "$GITHUB_ENV"
+          path: dist/
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ env.BUILD_NODE_VERSION }}
+          node-version: ${{ needs.build.outputs.NODE_VERSION }}
       - name: Setup cache
         uses: actions/cache@v4
         with:
@@ -121,17 +128,10 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-  bundle_winux:
+  bundle_win:
     if: github.ref_name == 'master'
-    runs-on: ubuntu-24.04
-    container:
-      image: electronuserland/builder:wine
+    runs-on: windows-2025
     needs: [build]
-    strategy:
-      matrix:
-        include:
-          - OS: "linux"
-          - OS: "win"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -141,12 +141,61 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: build-artifact
-      - name: Fetch node version
-        run: echo "BUILD_NODE_VERSION=$(grep -o -P -m 1 '(?<=node":\s").*(?=")' package.json)" >> "$GITHUB_ENV"
+          path: dist/
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ env.BUILD_NODE_VERSION }}
+          node-version: ${{ needs.build.outputs.NODE_VERSION }}
+      - name: Setup cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: npm-${{ hashFiles('package-lock.json') }}
+          restore-keys: npm-
+      - name: Install dependencies
+        run: npm install
+      - name: Bundle
+        run: npm run dist -- --win --x64 --publish never
+      - name: Upload codesign artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sign-win-artifact
+          path: |
+            output/*.exe
+            output/latest.yml
+          compression-level: 0
+          if-no-files-found: error
+          retention-days: 1
+      - name: Upload release artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-win-partial-artifact
+          path: |
+            output/*.exe.blockmap
+          compression-level: 0
+          if-no-files-found: error
+          retention-days: 1
+
+  bundle_linux:
+    if: github.ref_name == 'master'
+    runs-on: ubuntu-24.04
+    container:
+      image: electronuserland/builder:latest
+    needs: [build]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: build-artifact
+          path: dist/
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ needs.build.outputs.NODE_VERSION }}
       - name: Setup cache
         uses: actions/cache@v4
         with:
@@ -157,60 +206,33 @@ jobs:
         run: npm install
       - name: Bundle
         run: |
-          npm run dist -- --${{ matrix.OS }} --x64 --publish never
-      - name: Prepare output
-        id: output
-        run: |
-          VERSION=$(grep '"version"' package.json | head -n1 | sed -E 's/.*"version": *"([^"]+)".*/\1/')
-          echo "BUILD_VERSION=$VERSION" >> "$GITHUB_OUTPUT"
-      - name: Upload codesign artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: sign-${{ matrix.OS }}-artifact
-          path: |
-            output/*.AppImage
-            output/latest-linux.yml
-            output/*.exe
-            output/latest.yml
-          compression-level: 0
-          if-no-files-found: error
-          retention-days: 1
+          npm run dist -- --linux --x64 --publish never
       - name: Upload release artifact
         uses: actions/upload-artifact@v4
         with:
-          name: release-${{ matrix.OS}}-partial-artifact
+          name: release-linux-artifact
           path: |
+            output/*.AppImage
+            output/latest-linux.yml
             output/*.tar.gz
-            output/*.exe.blockmap
           compression-level: 0
           if-no-files-found: error
           retention-days: 1
-    outputs:
-      BUILD_VERSION: ${{ steps.output.outputs.BUILD_VERSION }}
 
-
-  sign_winux:
+  sign_win:
     if: github.ref_name == 'master'
     runs-on: [self-hosted, cs]
-    needs: [bundle_winux]
-    strategy:
-      matrix:
-        include:
-          - OS: "linux"
-            BUNDLE: "JUSTIFI-*.AppImage"
-            METADATA: "latest-linux.yml"
-          - OS: "win"
-            BUNDLE: "JUSTIFI-Setup-*.exe"
-            METADATA: "latest.yml"
+    needs: [bundle_win]
     steps:
       - name: Download artifact
         uses: actions/download-artifact@v4
         with:
-          name: sign-${{ matrix.OS }}-artifact
+          name: sign-win-artifact
+          path: output/
       - name: Codesign
         run: |
           TMP_CERT_PATH="$RUNNER_TEMP/cert.pem"
-          BUNDLE_PATH=$(find ./ -name "${{ matrix.BUNDLE }}")
+          BUNDLE_PATH=$(find ./ -name "JUSTIFI-Setup-*.exe")
 
           echo -n "${{ secrets.WIN_CERT_BASE64 }}" | base64 --decode -o $TMP_CERT_PATH
 
@@ -226,15 +248,14 @@ jobs:
             --env NEW_HASH=$(node ~/gen_hash.js -f $BUNDLE_PATH) \
             -v ./output:/output \
             ubuntu:latest \
-            sed -i "s|$OLD_HASH|$NEW_HASH|g" /output/${{ matrix.METADATA }}
+            sed -i "s|$OLD_HASH|$NEW_HASH|g" /output/latest.yml
       - name: Upload release artifact
         uses: actions/upload-artifact@v4
         with:
-          name: release-${{ matrix.OS }}-artifact
+          name: release-win-artifact
           path: |
-            ./*.AppImage
             ./*.exe
-            ./latest*.yml
+            ./latest.yml
           compression-level: 0
           if-no-files-found: error
           retention-days: 1
@@ -242,9 +263,9 @@ jobs:
   release:
     if: github.ref_name == 'master'
     runs-on: ubuntu-24.04
-    needs: [bundle_macos, sign_winux]
+    needs: [build, bundle_macos, bundle_linux, sign_win]
     env:
-      VERSION: ${{ needs.build.outputs.BUILD_VERSION }}
+      VERSION: ${{ needs.build.outputs.NODE_VERSION }}
     steps:
       - name: Get artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/release_desktop.yml
+++ b/.github/workflows/release_desktop.yml
@@ -245,7 +245,7 @@ jobs:
             $BUNDLE_PATH
 
           docker run \
-            --env OLD_HASH=$(ggrep -o -P -m 1 '(?<=sha512:\s).*' ./latest.yml) \
+            --env OLD_HASH=$(ggrep -o -P -m 1 '(?<=sha512:\s).*' ./output/latest.yml) \
             --env NEW_HASH=$(node ~/gen_hash.js -f $BUNDLE_PATH) \
             -v ./output:/output \
             ubuntu:latest \

--- a/.github/workflows/release_desktop.yml
+++ b/.github/workflows/release_desktop.yml
@@ -9,16 +9,18 @@ permissions:
 jobs:
   build:
     if: github.ref_name == 'master'
-    runs-on: [self-hosted, build]
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch_depth: 1
+          fetch-depth: 1
       - name: Fetch node version
-        run: echo "BUILD_NODE_VERSION=$(ggrep -o -P -m 1 '(?<=node":\s").*(?=")' package.json)" >> "$GITHUB_ENV"
+        run: echo "BUILD_NODE_VERSION=$(grep -o -P -m 1 '(?<=node":\s").*(?=")' package.json)" >> "$GITHUB_ENV"
       - name: Setup node
-        run: source ~/load_nvm.sh && nvm install ${{ env.BUILD_NODE_VERSION }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.BUILD_NODE_VERSION }}
       - name: Setup cache
         uses: actions/cache@v4
         with:
@@ -26,107 +28,215 @@ jobs:
           key: npm-${{ hashFiles('package-lock.json') }}
           restore-keys: npm-
       - name: Setup dependencies
-        run: |
-          TMP_PROV_PROF_PATH="$RUNNER_TEMP/embedded.provisionprofile"
-          TMP_WIN_CERT_PATH="$RUNNER_TEMP/cert_win.pem"
-
-          echo -n "${{ secrets.APPLE_PROV_PROF_BASE64 }}" | base64 --decode -o $TMP_PROV_PROF_PATH
-          echo -n "${{ secrets.WIN_CERT_BASE64 }}" | base64 --decode -o $TMP_WIN_CERT_PATH
-
-          cp "$TMP_PROV_PROF_PATH" ./embedded.provisionprofile
-          cp "$TMP_WIN_CERT_PATH" ./cert_win.pem
-
-          npm ci
-
-          security -v unlock-keychain -p "${{ secrets.APPLE_KC_SECRET }}" ~/Library/Keychains/login.keychain-db
+        run: npm ci
       - name: Build
         run: npm run build-prod-electron
-      - name: Bundle
-        run: |
-          npm run dist -- --mac --universal --publish never & (
-            docker run \
-              -v ./:/project \
-              electronuserland/builder:wine \
-              npm run dist -- --win --x64 --publish never &&
-            WIN_BUNDLE_PATH=$(find ./output -name "JUSTIFI-Setup-*.exe") &&
-            java -jar ~/jsign.jar \
-              --storetype "${{ secrets.WIN_STORE_TYPE }}" \
-              --storepass "${{ secrets.WIN_STORE_SECRET }}" \
-              --tsaurl "http://timestamp.sectigo.com" \
-              --certfile ./cert_win.pem \
-              $WIN_BUNDLE_PATH &&
-            OLD_HASH=$(ggrep -o -P -m 1 '(?<=sha512:\s).*' ./output/latest.yml) &&
-            NEW_HASH=$(node ~/gen_hash.js -f $WIN_BUNDLE_PATH) &&
-            docker run \
-              --env OLD_HASH=$OLD_HASH \
-              --env NEW_HASH=$NEW_HASH \
-              -v ./output:/output \
-              ubuntu:latest \
-              sed -i "s|$OLD_HASH|$NEW_HASH|g" /output/latest.yml
-          ) &
-          npm run dist -- --linux --x64 --publish never
-      - name: Prepare output
-        run: |
-          VERSION=$(ggrep -A3 'version:' ./output/latest-mac.yml | head -n1 | awk '{print $2}')
-          OUTPUT_DIR="$(pwd)/output"
-          echo "BUILD_VERSION=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "RUNNER_OUTPUT_DIR=$OUTPUT_DIR" >> "$GITHUB_ENV"
-      - name: Upload notarize artifact
+      - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: notarize-artifact
+          name: build-artifact
           path: |
-            ${{ env.RUNNER_OUTPUT_DIR }}/*.dmg
-          compression-level: 1
+            dist/
+            angular.json
+            package.json
+          compression-level: 6
           if-no-files-found: error
           retention-days: 1
-      - name: Upload Win/Linux artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: release-winux-artifact
-          path: |
-            ${{ env.RUNNER_OUTPUT_DIR }}/*
-            !${{ env.RUNNER_OUTPUT_DIR }}/*-unpacked
-            !${{ env.RUNNER_OUTPUT_DIR }}/*-universal
-            !${{ env.RUNNER_OUTPUT_DIR }}/*.dmg
-            !${{ env.RUNNER_OUTPUT_DIR }}/builder*
-          compression-level: 1
-          if-no-files-found: error
-          retention-days: 1
-    outputs:
-      BUILD_VERSION: ${{ steps.output.outputs.BUILD_VERSION }}
 
-  notarize:
+  bundle_macos:
     if: github.ref_name == 'master'
     runs-on: macos-13
     needs: [build]
     steps:
-      - name: Get artifact
+      - name: Download artifact
         uses: actions/download-artifact@v4
         with:
-          name: notarize-artifact
+          name: build-artifact
+      - name: Fetch node version
+        run: echo "BUILD_NODE_VERSION=$(grep -o -P -m 1 '(?<=node":\s").*(?=")' package.json)" >> "$GITHUB_ENV"
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.BUILD_NODE_VERSION }}
+      - name: Setup cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: npm-${{ hashFiles('package-lock.json') }}
+          restore-keys: npm-
+      - name: Install dependencies
+        run: npm ci
+      - name: Codesigning Setup
+        env:
+          APPLE_CERT_A_BASE64: ${{ secrets.APPLE_CERT_A_BASE64 }}
+          APPLE_CERT_I_BASE64: ${{ secrets.APPLE_CERT_I_BASE64 }}
+          APPLE_PROV_PROF_BASE64: ${{ secrets.APPLE_PROV_PROF_BASE64 }}
+          APPLE_CERT_SECRET: ${{ secrets.APPLE_CERT_SECRET }}
+          APPLE_KEYCHAIN_SECRET: ${{ secrets.APPLE_KEYCHAIN_SECRET }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SECRET: ${{ secrets.APPLE_APP_SECRET }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          CERT_A_PATH=$RUNNER_TEMP/app_certificate.p12
+          CERT_I_PATH=$RUNNER_TEMP/ins_certificate.p12
+          PROV_PROF_PATH=$RUNNER_TEMP/AMO.provisionprofile
+          KEYCHAIN_PATH=$RUNNER_TEMP/build.keychain
+
+          echo -n "$APPLE_CERT_A_BASE64" | base64 --decode -o $CERT_A_PATH
+          echo -n "$APPLE_CERT_I_BASE64" | base64 --decode -o $CERT_I_PATH
+          echo -n "$APPLE_PROV_PROF_BASE64" | base64 --decode -o $PROV_PROF_PATH
+
+          security -v create-keychain -p "$APPLE_KEYCHAIN_SECRET" $KEYCHAIN_PATH
+          security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
+          security -v default-keychain -s $KEYCHAIN_PATH
+          security -v unlock-keychain -p "$APPLE_KEYCHAIN_SECRET" $KEYCHAIN_PATH
+
+          security -v import $CERT_A_PATH -P "$APPLE_CERT_SECRET" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
+          security -v import $CERT_I_PATH -P "$APPLE_CERT_SECRET" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$APPLE_KEYCHAIN_SECRET" $KEYCHAIN_PATH
+
+          cp "$PROV_PROF_PATH" ./embedded.provisionprofile
+      - name: Bundle
+        run: npm run dist -- --mac --universal --publish never
       - name: Notarize
         run: |
           xcrun notarytool submit --wait \
             --apple-id "${{ secrets.APPLE_ID }}" \
             --password "${{ secrets.APPLE_APP_SECRET }}" \
             --team-id "${{ secrets.APPLE_TEAM_ID }}" \
-            $(find ./ -name "JUSTIFI-*.dmg") &&
-          sleep 60 &&
-          xcrun stapler staple $(find ./ -name "JUSTIFI-*.dmg")
-      - name: Upload notarized artifact
+            $(find ./output/ -name "JUSTIFI-*.dmg") &&
+          xcrun stapler staple $(find ./output/ -name "JUSTIFI-*.dmg")
+      - name: Upload release artifact
         uses: actions/upload-artifact@v4
         with:
           name: release-macos-artifact
-          path: ./*.dmg
-          compression-level: 1
+          path: |
+            output/*.zip
+            output/*.dmg
+            output/*.dmg.blockmap
+            output/latest*.yml
+          compression-level: 0
+          if-no-files-found: error
+          retention-days: 1
+
+  bundle_winux:
+    if: github.ref_name == 'master'
+    runs-on: ubuntu-24.04
+    container:
+      image: electronuserland/builder:wine
+    needs: [build]
+    strategy:
+      matrix:
+        include:
+          - OS: "linux"
+          - OS: "win"
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: build-artifact
+      - name: Fetch node version
+        run: echo "BUILD_NODE_VERSION=$(grep -o -P -m 1 '(?<=node":\s").*(?=")' package.json)" >> "$GITHUB_ENV"
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.BUILD_NODE_VERSION }}
+      - name: Setup cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: npm-${{ hashFiles('package-lock.json') }}
+          restore-keys: npm-
+      - name: Install dependencies
+        run: npm ci
+      - name: Bundle
+        run: |
+          npm run dist -- --${{ matrix.OS }} --x64 --publish never
+      - name: Prepare output
+        id: output
+        run: |
+          VERSION=$(grep '"version"' package.json | head -n1 | sed -E 's/.*"version": *"([^"]+)".*/\1/')
+          echo "BUILD_VERSION=$VERSION" >> "$GITHUB_OUTPUT"
+      - name: Upload codesign artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sign-${{ matrix.OS }}-artifact
+          path: |
+            output/*.AppImage
+            output/latest-linux.yml
+            output/*.exe
+            output/latest.yml
+          compression-level: 0
+          if-no-files-found: error
+          retention-days: 1
+      - name: Upload release artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-${{ matrix.OS}}-partial-artifact
+          path: |
+            output/*.tar.gz
+            output/*.exe.blockmap
+          compression-level: 0
+          if-no-files-found: error
+          retention-days: 1
+    outputs:
+      BUILD_VERSION: ${{ steps.output.outputs.BUILD_VERSION }}
+
+
+  sign_winux:
+    if: github.ref_name == 'master'
+    runs-on: [self-hosted, cs]
+    needs: [bundle_winux]
+    strategy:
+      matrix:
+        include:
+          - OS: "linux"
+            BUNDLE: "JUSTIFI-*.AppImage"
+            METADATA: "latest-linux.yml"
+          - OS: "win"
+            BUNDLE: "JUSTIFI-Setup-*.exe"
+            METADATA: "latest.yml"
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: sign-${{ matrix.OS }}-artifact
+      - name: Codesign
+        run: |
+          TMP_CERT_PATH="$RUNNER_TEMP/cert.pem"
+          BUNDLE_PATH=$(find ./ -name "${{ matrix.BUNDLE }}")
+
+          echo -n "${{ secrets.WIN_CERT_BASE64 }}" | base64 --decode -o $TMP_CERT_PATH
+
+          java -jar ~/jsign.jar \
+            --storetype "${{ secrets.WIN_STORE_TYPE }}" \
+            --storepass "${{ secrets.WIN_STORE_SECRET }}" \
+            --tsaurl "http://timestamp.sectigo.com" \
+            --certfile $TMP_WIN_CERT_PATH \
+            $BUNDLE_PATH
+
+          docker run \
+            --env OLD_HASH=$(ggrep -o -P -m 1 '(?<=sha512:\s).*' ./latest.yml) \
+            --env NEW_HASH=$(node ~/gen_hash.js -f $BUNDLE_PATH) \
+            -v ./output:/output \
+            ubuntu:latest \
+            sed -i "s|$OLD_HASH|$NEW_HASH|g" /output/${{ matrix.METADATA }}
+      - name: Upload release artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-${{ matrix.OS }}-artifact
+          path: |
+            ./*.AppImage
+            ./*.exe
+            ./latest*.yml
+          compression-level: 0
           if-no-files-found: error
           retention-days: 1
 
   release:
     if: github.ref_name == 'master'
     runs-on: ubuntu-24.04
-    needs: [build,notarize]
+    needs: [bundle_macos, sign_winux]
     env:
       VERSION: ${{ needs.build.outputs.BUILD_VERSION }}
     steps:
@@ -134,13 +244,15 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           pattern: release-*-artifact
+          path: release/
+          merge-multiple: true
       - name: Release
         uses: softprops/action-gh-release@v1
         with:
           name: JUSTIFI v${{ env.VERSION }}
           tag_name: v${{ env.VERSION }}
           draft: true
-          generate_release_nutes: false
+          generate_release_notes: false
           files: |
-            release-macos-artifact/*
-            release-winux-artifact/*
+            release/*
+        

--- a/.github/workflows/release_desktop.yml
+++ b/.github/workflows/release_desktop.yml
@@ -36,9 +36,7 @@ jobs:
         with:
           name: build-artifact
           path: |
-            dist/
-            angular.json
-            package.json
+            dist
           compression-level: 6
           if-no-files-found: error
           retention-days: 1
@@ -48,6 +46,10 @@ jobs:
     runs-on: macos-13
     needs: [build]
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
       - name: Download artifact
         uses: actions/download-artifact@v4
         with:
@@ -131,6 +133,10 @@ jobs:
           - OS: "linux"
           - OS: "win"
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
       - name: Download artifact
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/release_desktop.yml
+++ b/.github/workflows/release_desktop.yml
@@ -15,20 +15,20 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch_depth: 1
-      - name: Get Node version
-        run: echo "BUILD_NODE_VER=$(ggrep -o -P -m 1 '(?<=node":\s").*(?=")' package.json)" >> "$GITHUB_ENV"
-      - name: Node setup
-        run: source ~/load_nvm.sh && nvm install ${{ env.BUILD_NODE_VER }}
-      - name: Cache setup
+      - name: Fetch node version
+        run: echo "BUILD_NODE_VERSION=$(ggrep -o -P -m 1 '(?<=node":\s").*(?=")' package.json)" >> "$GITHUB_ENV"
+      - name: Setup node
+        run: source ~/load_nvm.sh && nvm install ${{ env.BUILD_NODE_VERSION }}
+      - name: Setup cache
         uses: actions/cache@v4
         with:
           path: ~/.npm
           key: npm-${{ hashFiles('package-lock.json') }}
           restore-keys: npm-
-      - name: Dependency setup
+      - name: Setup dependencies
         run: |
-          TMP_PROV_PROF_PATH=$RUNNER_TEMP/embedded.provisionprofile
-          TMP_WIN_CERT_PATH=$RUNNER_TEMP/cert_win.pem
+          TMP_PROV_PROF_PATH="$RUNNER_TEMP/embedded.provisionprofile"
+          TMP_WIN_CERT_PATH="$RUNNER_TEMP/cert_win.pem"
 
           echo -n "${{ secrets.APPLE_PROV_PROF_BASE64 }}" | base64 --decode -o $TMP_PROV_PROF_PATH
           echo -n "${{ secrets.WIN_CERT_BASE64 }}" | base64 --decode -o $TMP_WIN_CERT_PATH
@@ -36,7 +36,8 @@ jobs:
           cp "$TMP_PROV_PROF_PATH" ./embedded.provisionprofile
           cp "$TMP_WIN_CERT_PATH" ./cert_win.pem
 
-          npm ci && npm install -g electron-builder
+          npm ci
+          npm install -g electron-builder
 
           security -v unlock-keychain -p "${{ secrets.KC_SECRET }}" ~/Library/Keychains/login.keychain-db
       - name: Build
@@ -44,38 +45,38 @@ jobs:
       - name: Bundle
         run: |
           electron-builder --mac --universal --publish never & (
-          electron-builder --win --x64 --publish never &&
-          WIN_BUNDLE_PATH=$(find ./output -name "JUSTIFI-*-*.exe") &&
-          java -jar ~/jsign.jar \
-            --storetype "${{ secrets.WIN_STORE_TYPE }}" \
-            --storepass "${{ secrets.WIN_STORE_SECRET }}" \
-            --tsaurl "http://timestamp.sectigo.com" \
-            --certfile ./cert_win.pem \
-            WIN_BUNDLE_PATH &&
-          OLD_HASH=$(ggrep -o -P -m 1 '(?<=sha512:\s).*' ./output/latest.yml) &&
-          NEW_HASH=$(node ~/gen_hash.js -f $WIN_BUNDLE_PATH) &&
-          docker run -v ./output:/output ubuntu:latest bash -c 'sed "s/$OLD_HASH/$NEW_HASH/g" /output/latest.yml'
+            electron-builder --win --x64 --publish never &&
+            WIN_BUNDLE_PATH=$(find ./output -name "JUSTIFI-*-*.exe") &&
+            java -jar ~/jsign.jar \
+              --storetype "${{ secrets.WIN_STORE_TYPE }}" \
+              --storepass "${{ secrets.WIN_STORE_SECRET }}" \
+              --tsaurl "http://timestamp.sectigo.com" \
+              --certfile ./cert_win.pem \
+              $WIN_BUNDLE_PATH &&
+            OLD_HASH=$(ggrep -o -P -m 1 '(?<=sha512:\s).*' ./output/latest.yml) &&
+            NEW_HASH=$(node ~/gen_hash.js -f $WIN_BUNDLE_PATH) &&
+            docker run -v ./output:/output ubuntu:latest bash -c 'sed "s/$OLD_HASH/$NEW_HASH/g" ./output/latest.yml'
           ) &
           electron-builder --linux --x64 --publish never
       - name: Prepare output
         run: |
-          VERSION=$(ggrep -A3 'version:' ../output/latest-mac.yml | head -n1 | awk '{print $2}')
+          VERSION=$(ggrep -A3 'version:' ./output/latest-mac.yml | head -n1 | awk '{print $2}')
           OUTPUT_DIR="$(pwd)/output"
           echo "BUILD_VERSION=$VERSION" >> "$GITHUB_OUTPUT"
           echo "RUNNER_OUTPUT_DIR=$OUTPUT_DIR" >> "$GITHUB_ENV"
-      - name: Upload notarization artifacts
+      - name: Upload notarize artifact
         uses: actions/upload-artifact@v4
         with:
-          name: notarization-artifact
+          name: notarize-artifact
           path: |
             ${{ env.RUNNER_OUTPUT_DIR }}/*.dmg
           compression-level: 1
           if-no-files-found: error
           retention-days: 1
-      - name: Upload winux artifacts
+      - name: Upload Win/Linux artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: winux-release-artifact
+          name: release-winux-artifact
           path: |
             ${{ env.RUNNER_OUTPUT_DIR }}/*
             !${{ env.RUNNER_OUTPUT_DIR }}/*-unpacked
@@ -86,26 +87,30 @@ jobs:
           if-no-files-found: error
           retention-days: 1
     outputs:
-            BUILD_VERSION: ${{ steps.output.outputs.BUILD_VERSION }}
+      BUILD_VERSION: ${{ steps.output.outputs.BUILD_VERSION }}
 
-  notarization:
+  notarize:
     if: github.ref_name == 'master'
     runs-on: macos-13
     needs: [build]
     steps:
-      - name: Get artifacts
+      - name: Get artifact
         uses: actions/download-artifact@v4
         with:
-          name: notarization-artifact
+          name: notarize-artifact
       - name: Notarize
         run: |
-          xcrun notarytool submit --wait --apple-id "${{ secrets.APPLE_ID }}" --password "${{ secrets.APPLE_APP_SECRET }}" --team-id "${{ secrets.APPLE_TEAM_ID }}" $(find ./ -name "JUSTIFI-*-*.dmg") &&
+          xcrun notarytool submit --wait \
+            --apple-id "${{ secrets.APPLE_ID }}" \
+            --password "${{ secrets.APPLE_APP_SECRET }}" \
+            --team-id "${{ secrets.APPLE_TEAM_ID }}" \
+            $(find ./ -name "JUSTIFI-*-*.dmg") &&
           sleep 60 &&
           xcrun stapler staple $(find ./ -name "JUSTIFI-*-*.dmg")
       - name: Upload notarized artifact
         uses: actions/upload-artifact@v4
         with:
-          name: macos-release-artifact
+          name: release-macos-artifact
           path: ./*.dmg
           compression-level: 1
           if-no-files-found: error
@@ -113,23 +118,22 @@ jobs:
 
   release:
     if: github.ref_name == 'master'
-    runs-on: ubuntu-22.04
-    needs: [build,notarization]
+    runs-on: ubuntu-24.04
+    needs: [build,notarize]
     env:
       VERSION: ${{ needs.build.outputs.BUILD_VERSION }}
     steps:
       - name: Get artifacts
         uses: actions/download-artifact@v4
         with:
-          pattern: *-release-artifact
+          pattern: release-*-artifact
       - name: Release
         uses: softprops/action-gh-release@v1
-        # if: startsWith(github.ref, 'refs/tags/') # Uncomment if enabling tag gating
         with:
           name: JUSTIFI v${{ env.VERSION }}
           tag_name: v${{ env.VERSION }}
-          draft: true # Comment out if enabling tag gating and publishing via action
-          generate_release_notes: false
+          draft: true
+          generate_release_nutes: false
           files: |
-            macos-release-artifact/*
-            winux-release-artifact/*
+            release-macos-artifact/*
+            release-winux-artifact/*

--- a/.github/workflows/release_desktop.yml
+++ b/.github/workflows/release_desktop.yml
@@ -37,15 +37,14 @@ jobs:
           cp "$TMP_WIN_CERT_PATH" ./cert_win.pem
 
           npm ci
-          npm install -g electron-builder
 
           security -v unlock-keychain -p "${{ secrets.KC_SECRET }}" ~/Library/Keychains/login.keychain-db
       - name: Build
         run: npm run build-prod-electron
       - name: Bundle
         run: |
-          electron-builder --mac --universal --publish never & (
-            electron-builder --win --x64 --publish never &&
+          npm run dist -- --mac --universal --publish never & (
+            npm run dist -- --win --x64 --publish never &&
             WIN_BUNDLE_PATH=$(find ./output -name "JUSTIFI-*-*.exe") &&
             java -jar ~/jsign.jar \
               --storetype "${{ secrets.WIN_STORE_TYPE }}" \
@@ -57,7 +56,7 @@ jobs:
             NEW_HASH=$(node ~/gen_hash.js -f $WIN_BUNDLE_PATH) &&
             docker run -v ./output:/output ubuntu:latest bash -c 'sed "s/$OLD_HASH/$NEW_HASH/g" ./output/latest.yml'
           ) &
-          electron-builder --linux --x64 --publish never
+          npm run dist -- --linux --x64 --publish never
       - name: Prepare output
         run: |
           VERSION=$(ggrep -A3 'version:' ./output/latest-mac.yml | head -n1 | awk '{print $2}')

--- a/.github/workflows/release_desktop.yml
+++ b/.github/workflows/release_desktop.yml
@@ -82,13 +82,10 @@ jobs:
           APPLE_PROV_PROF_BASE64: ${{ secrets.APPLE_PROV_PROF_BASE64 }}
           APPLE_CERT_SECRET: ${{ secrets.APPLE_CERT_SECRET }}
           APPLE_KEYCHAIN_SECRET: ${{ secrets.APPLE_KEYCHAIN_SECRET }}
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_APP_SECRET: ${{ secrets.APPLE_APP_SECRET }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
           CERT_A_PATH=$RUNNER_TEMP/app_certificate.p12
           CERT_I_PATH=$RUNNER_TEMP/ins_certificate.p12
-          PROV_PROF_PATH=$RUNNER_TEMP/AMO.provisionprofile
+          PROV_PROF_PATH=$RUNNER_TEMP/embedded.provisionprofile
           KEYCHAIN_PATH=$RUNNER_TEMP/build.keychain
 
           echo -n "$APPLE_CERT_A_BASE64" | base64 --decode -o $CERT_A_PATH
@@ -106,21 +103,30 @@ jobs:
 
           cp "$PROV_PROF_PATH" ./embedded.provisionprofile
       - name: Bundle
-        run: npm run dist -- --mac --universal --publish never
+        run: npm run dist -- --mac --x64 --arm64 --publish never
       - name: Notarize
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SECRET: ${{ secrets.APPLE_APP_SECRET }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
-          xcrun notarytool submit --wait \
-            --apple-id "${{ secrets.APPLE_ID }}" \
-            --password "${{ secrets.APPLE_APP_SECRET }}" \
-            --team-id "${{ secrets.APPLE_TEAM_ID }}" \
-            $(find ./output/ -name "JUSTIFI-*.dmg") &&
-          xcrun stapler staple $(find ./output/ -name "JUSTIFI-*.dmg")
+          BINARIES=($(find ./output/ -name "JUSTIFI-*-arm64.dmg") $(find ./output/ -name "JUSTIFI-*-x64.dmg"))
+          for BINARY in "${BINARIES[@]}"; do
+            xcrun notarytool submit --wait \
+              --apple-id "$APPLE_ID" \
+              --password "$APPLE_APP_SECRET" \
+              --team-id "$APPLE_TEAM_ID" \
+              $BINARY &&
+            sleep 30 &&
+            xcrun stapler staple $BINARY
+          done
       - name: Upload release artifact
         uses: actions/upload-artifact@v4
         with:
           name: release-macos-artifact
           path: |
             output/*.zip
+            output/*.zip.blockmap
             output/*.dmg
             output/*.dmg.blockmap
             output/latest*.yml

--- a/.github/workflows/release_web.yml
+++ b/.github/workflows/release_web.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   build:
+    if: github.ref_name == 'develop' || github.ref_name == 'master'
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
@@ -14,11 +15,11 @@ jobs:
           submodules: true
           lfs: false
       - name: Get Node version
-        run: echo "BUILD_NODE_VER=$(grep -o -P -m 1 '(?<=node":\s").*(?=")' package.json)" >> $GITHUB_ENV
+        run: echo "BUILD_NODE_VERSION=$(grep -o -P -m 1 '(?<=node":\s").*(?=")' package.json)" >> $GITHUB_ENV
       - name: Node setup
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ env.BUILD_NODE_VER }}
+          node-version: ${{ env.BUILD_NODE_VERSION }}
       - name: Attach SHA to build
         if: github.ref_name == 'develop'
         run: |
@@ -42,7 +43,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: dist
-          path: ./dist/neb-tool/browser
+          path: ./dist/browser
           if-no-files-found: error
           retention-days: 3
   

--- a/.github/workflows/release_web.yml
+++ b/.github/workflows/release_web.yml
@@ -1,4 +1,4 @@
-name: Web
+name: "Release: Web"
 
 on:
   workflow_call:

--- a/.github/workflows/util_ci.yml
+++ b/.github/workflows/util_ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: "Util: CI"
 
 on:
   pull_request:

--- a/.github/workflows/util_mirror.yml
+++ b/.github/workflows/util_mirror.yml
@@ -1,4 +1,4 @@
-name: Sync Mirror
+name: "Util: Mirror"
 
 on:
   workflow_dispatch:

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ If you plan to contribute your code changes to this repository, please review th
 
 - `npm run dist` will create electron installers for your operating system
 
-- Installer will be created in an `./output/neb-tool/` directory 
+- Installer will be created in an `./output/` directory 
 
 
 ## Running unit tests

--- a/angular.json
+++ b/angular.json
@@ -18,7 +18,7 @@
           "builder": "@angular-devkit/build-angular:application",
           "options": {
             "outputPath": {
-              "base": "dist/neb-tool"
+              "base": "dist/"
             },
             "index": "src/index.html",
             "polyfills": [

--- a/entitlements.mac.inherit.plist
+++ b/entitlements.mac.inherit.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+    <key>com.apple.security.cs.disable-executable-page-protection</key>
+    <true/>
+  </dict>
+</plist>

--- a/main.js
+++ b/main.js
@@ -33,7 +33,7 @@ app.on('ready', function () {
 
     // Specify entry point
     win.loadURL(url.format({
-        pathname: path.join(__dirname, 'dist/neb-tool/browser/index.html'),
+        pathname: path.join(__dirname, 'dist/browser/index.html'),
         protocol: 'file',
         slashes: true
     }));

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
       ],
       "icon": "src/assets/icons/justifi-icon-512x512.png",
       "artifactName": "${productName}-${version}-${arch}.${ext}",
-      "hardenedRuntime": false,
+      "hardenedRuntime": true,
       "gatekeeperAssess": false,
       "provisioningProfile": "./embedded.provisionprofile",
       "entitlements": "entitlements.mac.inherit.plist",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
       ],
       "icon": "src/assets/icons/",
       "executableName": "JUSTIFI",
-      "maintainer": "National Renewable Energy Laboratory",
+      "maintainer": "Oak Ridge National Laboratory",
       "artifactName": "${productName}-${version}.${ext}",
       "category": "Science"
     },
@@ -56,6 +56,7 @@
         "zip"
       ],
       "icon": "src/assets/icons/justifi-icon-512x512.png",
+      "artifactName": "${productName}-${version}-${arch}.${ext}",
       "hardenedRuntime": false,
       "gatekeeperAssess": false,
       "provisioningProfile": "./embedded.provisionprofile",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,10 @@
       ],
       "icon": "src/assets/icons/justifi-icon-512x512.png",
       "hardenedRuntime": false,
-      "gatekeeperAssess": false
+      "gatekeeperAssess": false,
+      "provisioningProfile": "./embedded.provisionprofile",
+      "entitlements": "entitlements.mac.inherit.plist",
+      "entitlementsInherit": "entitlements.mac.inherit.plist"
     }
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
   },
   "private": true,
   "build": {
-    "appId": "gov.nrel.justifi",
-    "copyright": "Copyright 2023 NREL. All rights reserved.",
+    "appId": "gov.ornl.justifi",
+    "copyright": "Copyright 2025 ORNL. All rights reserved.",
     "productName": "JUSTIFI",
     "directories": {
       "output": "./output/"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "copyright": "Copyright 2023 NREL. All rights reserved.",
     "productName": "JUSTIFI",
     "directories": {
-      "output": "./output/justifi/"
+      "output": "./output/"
     },
     "win": {
       "target": "nsis",


### PR DESCRIPTION
Add support for building and releasing desktop binaries for the following platforms and architectures:
  - MacOS x64 `.dmg`, `.zip`
  - MacOS arm64 `.dmg`,`.zip`
  - Windows x64 `.exe`
  - Linux x64 `.AppImage`, `.tar.gz`

Codesigning (and notarization for MacOS) have been implemented for Windows and MacOS release - Linux codesigning to be implemented at a later date.

For release drafts, the version associated with the release name and its tag is retrieved from the version specified in the `package.json`.