### PR TITLE
ci/codesigning-relocation - Relocate codesigning

### DIFF
--- a/.github/workflows/release_desktop.yml
+++ b/.github/workflows/release_desktop.yml
@@ -235,7 +235,7 @@ jobs:
           TMP_CERT_PATH="$RUNNER_TEMP/cert.pem"
           BUNDLE_PATH=$(find . -name "JUSTIFI-Setup-*.exe")
 
-          echo -n "${{ secrets.WIN_CERT_BASE64 }}" | base64 --decode -o $TMP_CERT_PATH
+          echo -n "${{ secrets.WIN_CERT_BASE64 }}" | base64 --decode > $TMP_CERT_PATH
 
           jsign --storetype "${{ secrets.WIN_STORE_TYPE }}" \
                 --storepass "${{ secrets.WIN_STORE_SECRET }}" \

--- a/.github/workflows/release_desktop.yml
+++ b/.github/workflows/release_desktop.yml
@@ -237,22 +237,15 @@ jobs:
 
           echo -n "${{ secrets.WIN_CERT_BASE64 }}" | base64 --decode -o $TMP_CERT_PATH
 
-          java -jar ~/jsign.jar \
-            --storetype "${{ secrets.WIN_STORE_TYPE }}" \
-            --storepass "${{ secrets.WIN_STORE_SECRET }}" \
-            --tsaurl "http://timestamp.sectigo.com" \
-            --certfile $TMP_CERT_PATH \
-            $BUNDLE_PATH
+          jsign --storetype "${{ secrets.WIN_STORE_TYPE }}" \
+                --storepass "${{ secrets.WIN_STORE_SECRET }}" \
+                --tsaurl "http://timestamp.sectigo.com" \
+                --certfile $TMP_CERT_PATH \
+                $BUNDLE_PATH
 
-          OLD_HASH=$(ggrep -o -P -m 1 '(?<=sha512:\s).*' ./output/latest.yml)
-          NEW_HASH=$(node ~/gen_hash.js -f "$BUNDLE_PATH")
-
-          docker run \
-            --env OLD_HASH="$OLD_HASH" \
-            --env NEW_HASH="$NEW_HASH" \
-            -v ./output:/output \
-            ubuntu:latest \
-            sed -i "s|$OLD_HASH|$NEW_HASH|g" /output/latest.yml
+          OLD_HASH=$(grep -o -P -m 1 '(?<=sha512:\s).*' ./output/latest.yml)
+          NEW_HASH=$(gen_hash -f "$BUNDLE_PATH")
+          sed -i "s|$OLD_HASH|$NEW_HASH|g" ./output/latest.yml
       - name: Upload release artifact
         uses: actions/upload-artifact@v4
         with:
@@ -288,4 +281,3 @@ jobs:
           generate_release_notes: false
           files: |
             release/*
-        


### PR DESCRIPTION
Relocate codesigning to Linux-based runner - correct signing and find-and-replace logic.