### PR TITLE
Issue 124: update modal styles for scrolling modals

### DIFF
--- a/src/assets/styles/modals.css
+++ b/src/assets/styles/modals.css
@@ -10,7 +10,7 @@
 }
 
 .tooltip {
-  z-index: 99999 !important; 
+    z-index: 99999 !important;
 }
 
 .popup {
@@ -26,6 +26,9 @@
     top: 5%;
     background-color: white;
     transition: 0.2s transform;
+    max-height: calc(90vh);
+    display: flex;
+    flex-direction: column;
 }
 
 .popup.open {
@@ -36,21 +39,25 @@
     padding: 10px;
     font-weight: bold;
     /* border-radius: 3px 3px 0 0; */
+    height: 45px;
 }
 
 .popup .popup-body {
     background-color: #ffffff;
     color: black;
     padding: 10px;
+    flex: 1 1 auto;
+    overflow-y: auto;
 }
 
 .popup .popup-footer {
+    padding-top: 10px;
     padding-right: 10px;
     padding-left: 10px;
     padding-bottom: 10px;
 }
 
-.lg-popup.popup{
+.lg-popup.popup {
     width: 98%;
     left: 1%;
     bottom: 1%;
@@ -58,11 +65,11 @@
     top: 1%
 }
 
-.lg-popup.popup .popup-body{
+.lg-popup.popup .popup-body {
     height: calc(98vh - 125px);
     overflow-y: auto;
 }
 
-.toast .toast-body{
+.toast .toast-body {
     background-color: white;
 }


### PR DESCRIPTION
connects #124 

This pull request updates the modal styles to improve layout and usability, particularly for popups with longer content. The main changes focus on making the modal more flexible and ensuring content is scrollable when needed.

**Modal layout and scrolling improvements:**

* The `.popup` container now uses a flex column layout and has a maximum height of 90% of the viewport, preventing it from growing too large and ensuring content fits within the screen.
* The `.popup-header` has a fixed height for consistency in appearance.
* The `.popup-body` is now flexible and scrollable, allowing overflow content to be accessed without expanding the modal beyond its maximum height.
* The `.popup-footer` has improved padding for better spacing.