### PR TITLE
Issue 142 - add export to excel option in the Follow-up screen

### DIFF
--- a/src/app/setup-wizard/data-evaluation/data-follow-up/data-follow-up.component.css
+++ b/src/app/setup-wizard/data-evaluation/data-follow-up/data-follow-up.component.css
@@ -1,0 +1,15 @@
+.action-btn {
+    background-color: #873e23;
+    border-color: #873e23;
+    color: white;
+}
+
+.action-btn:disabled, .action-btn:disabled:hover {
+    background-color: #c3a296;
+    border-color: #c3a296;
+    color: white;
+}
+
+.card-style {
+    background-color: #eeeeee;
+}

--- a/src/app/setup-wizard/data-evaluation/data-follow-up/data-follow-up.component.html
+++ b/src/app/setup-wizard/data-evaluation/data-follow-up/data-follow-up.component.html
@@ -62,10 +62,37 @@
                         </li>
                     </ul>
                 </ng-template>
+
+                <div class="card mt-5 card-style">
+                    <div class="card-body d-flex flex-column align-items-center justify-content-center text-center">
+                        <h5 class="mb-2">
+                            Facility Protocol Questions
+                        </h5>
+                        <div class="mb-4 fst-italic">
+                            Click the link to view or edit protocol questions for this facility and click the button to export the questions to Excel.
+                        </div>
+                        <div class="d-flex">
+                            <div class="mb-2 me-3">
+                                <a class="btn btn-link p-0" (click)="navigateToQuestions()">
+                                    View/Edit Protocol Questions
+                                </a>
+                            </div>
+                            <div>
+                                <button class="btn action-btn btn-sm" (click)="openExportModal()">
+                                    <fa-icon class="me-1" [icon]="faFileExcel"></fa-icon>
+                                    Export Questions to Excel
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
             </div>
         </div>
     </div>
 </div>
+
+<app-protocol-questions-modal [selectedModule]="selectedModule"></app-protocol-questions-modal>
+
 <nav class="setup-wizard-footer navbar shadow">
     <div class="container-fluid justify-content-between">
         <div class="col-3">

--- a/src/app/setup-wizard/data-evaluation/data-follow-up/data-follow-up.component.spec.ts
+++ b/src/app/setup-wizard/data-evaluation/data-follow-up/data-follow-up.component.spec.ts
@@ -4,6 +4,8 @@ import { DataFollowUpComponent } from './data-follow-up.component';
 import { RouterTestingModule } from '@angular/router/testing';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { stubServiceProviders } from 'src/app/spec-helpers/spec-test-service-stub';
+import { ProtocolQuestionsModalComponent } from 'src/app/user-portfolio/facility-dashboard/protocol-questions-modal/protocol-questions-modal.component';
+import { FormsModule } from '@angular/forms';
 
 describe('DataFollowUpComponent', () => {
   let component: DataFollowUpComponent;
@@ -11,8 +13,8 @@ describe('DataFollowUpComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [RouterTestingModule, FontAwesomeModule],
-      declarations: [DataFollowUpComponent],
+      imports: [RouterTestingModule, FontAwesomeModule, FormsModule],
+      declarations: [DataFollowUpComponent, ProtocolQuestionsModalComponent],
       providers: stubServiceProviders
     })
     .compileComponents();

--- a/src/app/setup-wizard/data-evaluation/data-follow-up/data-follow-up.component.ts
+++ b/src/app/setup-wizard/data-evaluation/data-follow-up/data-follow-up.component.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 import { Router } from '@angular/router';
-import { IconDefinition, faChevronLeft, faChevronRight, faExclamationCircle, faPersonWalkingArrowLoopLeft } from '@fortawesome/free-solid-svg-icons';
+import { IconDefinition, faChevronLeft, faChevronRight, faExclamationCircle, faFileExcel, faPersonWalkingArrowLoopLeft } from '@fortawesome/free-solid-svg-icons';
 import { AssessmentIdbService } from 'src/app/indexed-db/assessment-idb.service';
 import { EnergyOpportunityIdbService } from 'src/app/indexed-db/energy-opportunity-idb.service';
 import { FacilityIdbService } from 'src/app/indexed-db/facility-idb.service';
@@ -13,6 +13,7 @@ import { IdbNonEnergyBenefit } from 'src/app/models/nonEnergyBenefit';
 import { IdbOnSiteVisit } from 'src/app/models/onSiteVisit';
 import { UtilityOptions } from 'src/app/shared/constants/utilityTypes';
 import { LocalStorageDataService } from 'src/app/shared/shared-services/local-storage-data.service';
+import { ProtocolQuestionsExcelWriterService } from 'src/app/shared/shared-services/protocol-questions-excel-writer.service';
 
 @Component({
   selector: 'app-data-follow-up',
@@ -26,6 +27,7 @@ export class DataFollowUpComponent {
   faChevronRight: IconDefinition = faChevronRight;
   faPersonWalkingArrowLoopLeft: IconDefinition = faPersonWalkingArrowLoopLeft;
   faExclamationCircle: IconDefinition = faExclamationCircle;
+  faFileExcel: IconDefinition = faFileExcel;
 
   onSiteVisit: IdbOnSiteVisit;
 
@@ -35,12 +37,13 @@ export class DataFollowUpComponent {
   numEnergyOpportunities: number = 0;
   numNonEnergyBenefits: number = 0;
 
-
   followUpItems: Array<{
     label: string,
     linkUrl: string,
     energyOppGuid?: string
   }>;
+
+  selectedModule = 'all';
 
   constructor(private router: Router,
     private onSiteVisitIdbService: OnSiteVisitIdbService,
@@ -48,7 +51,8 @@ export class DataFollowUpComponent {
     private energyOpportunityIdbService: EnergyOpportunityIdbService,
     private nonEnergyBenefitsIdbService: NonEnergyBenefitsIdbService,
     private assessmentIdbService: AssessmentIdbService,
-    private localStorageDataService: LocalStorageDataService
+    private localStorageDataService: LocalStorageDataService,
+    private protocolQuestionsExcelWriterService: ProtocolQuestionsExcelWriterService
   ) {
 
   }
@@ -163,5 +167,13 @@ export class DataFollowUpComponent {
       this.localStorageDataService.setEnergyOppAccordionGuid(item.energyOppGuid);
     }
     this.router.navigateByUrl(item.linkUrl);
+  }
+
+  navigateToQuestions() {
+    this.router.navigateByUrl('/portfolio/facility/'+ this.facility.guid + '/questions');
+  }
+
+  openExportModal() {
+    this.protocolQuestionsExcelWriterService.displayProtocolQuestionsModal.next(true);
   }
 }

--- a/src/app/setup-wizard/setup-wizard.module.ts
+++ b/src/app/setup-wizard/setup-wizard.module.ts
@@ -56,6 +56,7 @@ import { DataEvaluationManageReportsComponent } from './data-evaluation/data-eva
 import { DataEvaluationCustomReportComponent } from './data-evaluation/data-evaluation-custom-report/data-evaluation-custom-report.component';
 import { ExecutiveSummaryEvaluationComponent } from './data-evaluation/executive-summary-evaluation/executive-summary-evaluation.component';
 import { UploadTemplateComponent } from './upload-template/upload-template.component';
+import { UserPortfolioModule } from '../user-portfolio/user-portfolio.module';
 
 @NgModule({
   declarations: [
@@ -118,7 +119,8 @@ import { UploadTemplateComponent } from './upload-template/upload-template.compo
     SharedFacilityFormsModule,
     AssociatedContactsModule,
     AssociatedEnergyEquipmentModule,
-    AssociatedProcessEquipmentModule
+    AssociatedProcessEquipmentModule,
+    UserPortfolioModule
 ]
 })
 export class SetupWizardModule { }

--- a/src/app/user-portfolio/facility-dashboard/protocol-questions-modal/protocol-questions-modal.component.ts
+++ b/src/app/user-portfolio/facility-dashboard/protocol-questions-modal/protocol-questions-modal.component.ts
@@ -93,6 +93,13 @@ export class ProtocolQuestionsModalComponent {
         this.isEndUseSelected = true;
         this.selectedChildrenEndUse = [...this.processEquipmentIds];
         break;
+      case 'all':
+        this.isFacilitySelected = true;
+        this.isIndustrialSystemSelected = true;
+        this.isEndUseSelected = true;
+        this.selectedChildrenIndustrialSys = [...this.energyEquipmentIds];
+        this.selectedChildrenEndUse = [...this.processEquipmentIds];
+        break;
     }
   }
 

--- a/src/app/user-portfolio/user-portfolio.module.ts
+++ b/src/app/user-portfolio/user-portfolio.module.ts
@@ -106,6 +106,9 @@ import { ProtocolQuestionsModalComponent } from './facility-dashboard/protocol-q
     AssociatedContactsModule,
     FormsModule,
     ReactiveFormsModule
+],
+exports: [
+  ProtocolQuestionsModalComponent
 ]
 })
 export class UserPortfolioModule { }


### PR DESCRIPTION
connects #142 

This pull request introduces a new "Facility Protocol Questions" section to the data follow-up view, allowing users to view, edit, and export protocol questions for a facility. It also improves modularity by integrating the protocol questions modal and related services, and updates styles and test configurations to support these features.

**Feature Additions:**

* Added a new card to `data-follow-up.component.html` for "Facility Protocol Questions", including a link to view/edit questions and a button to export questions to Excel.
* Implemented `navigateToQuestions()` and `openExportModal()` methods in `data-follow-up.component.ts` to handle navigation and modal display for protocol questions.

**Styling Updates:**

* Added new CSS classes `.action-btn` and `.card-style` to `data-follow-up.component.css` for improved button and card appearance.

**Component & Service Integration:**

* Imported and declared `ProtocolQuestionsModalComponent` and `ProtocolQuestionsExcelWriterService` in relevant modules and components to support modal functionality and Excel export.

**Modal Behavior Enhancement:**

* Updated `ProtocolQuestionsModalComponent` to support selecting all modules at once when "all" is chosen, ensuring all protocol questions are included for export or editing.