### PR TITLE
Issue 144: Return to visit button confusion

### DIFF
--- a/src/app/user-portfolio/user-portfolio.component.ts
+++ b/src/app/user-portfolio/user-portfolio.component.ts
@@ -154,6 +154,10 @@ export class UserPortfolioComponent {
     } else {
       this.displayVisitButton = false;
     }
+    //hide button and don't show again
+    if (!this.displayVisitButton && this.onSiteVisit) {
+      this.onSiteVisitIdbService.selectedVisit.next(undefined);
+    }
   }
 
   returnToVisit() {


### PR DESCRIPTION
#144 

A button displays when navigating from the wizard to the portfolio to "Return to Visit" the logic we had setup would hide and show it depending on the context of the portfolio. This was confusing. I modified it to hide the button if the user leaves the context of the visit they were originally in. Diff company, assessment, facility etc.

