### PR TITLE
Issue 131: Update License and About Page with User Notice

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -15,3 +15,9 @@ Subject to the conditions of this License, Alliance for Sustainable Energy, LLC 
 DISCLAIMER
 ALLIANCE FOR SUSTAINABLE ENERGY, LLC, UT-BATTELLE, LLC AND THE GOVERNMENT MAKE NO REPRESENTATIONS AND DISCLAIM ALL WARRANTIES, BOTH EXPRESSED AND IMPLIED.  THERE ARE NO EXPRESS OR IMPLIED WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE, OR THAT THE USE OF THE SOFTWARE WILL NOT INFRINGE ANY PATENT, COPYRIGHT, TRADEMARK, OR OTHER PROPRIETARY RIGHTS, OR THAT THE SOFTWARE WILL ACCOMPLISH THE INTENDED RESULTS OR THAT THE SOFTWARE OR ITS USE WILL NOT RESULT IN INJURY OR DAMAGE.  THE USER ASSUMES RESPONSIBILITY FOR ALL LIABILITIES, PENALTIES, FINES, CLAIMS, CAUSES OF ACTION, AND COSTS AND EXPENSES, CAUSED BY, RESULTING FROM OR ARISING OUT OF, IN WHOLE OR IN PART THE USE, STORAGE OR DISPOSAL OF THE SOFTWARE.
 ****************************************************************************************************************
+
+****************************************************************************************************************
+NOTICE TO USERS
+
+Note that users should be aware that finding non-energy benefits can vary and are not guaranteed. The use of the JUSTIFI tool does not constitute or imply any endorsement, recommendation, or favoring of any entity, product, or service. Please refer to the terms and disclaimer located in this LICENSE file and in the application's documentation for more information.
+****************************************************************************************************************

--- a/src/app/core-components/about/about.component.html
+++ b/src/app/core-components/about/about.component.html
@@ -7,14 +7,15 @@
             </h4>
             <p>
                 The JUSTIFI tool was developed by staff at Oak Ridge
-                National Laboratory (ORNL) and the National Renewable Energy Laboratory (NREL) and in collaboration with the
+                National Laboratory (ORNL) and the National Renewable Energy Laboratory (NREL) and in collaboration with
+                the
                 U.S. Department of Energy. This software tool was funded by the U.S. Department of Energy's Office of
                 Energy Efficiency and Renewable Energy under National Renewable Energy Laboratory Contract No.
                 DE-AC36-08GO28308 and Oak Ridge National Laboratory Contract No.
                 DE-AC05-00OR22725.
             </p>
             <p>
-                This Software is provided for research purposes only. ORNL and NREL has no obligation to 
+                This Software is provided for research purposes only. ORNL and NREL has no obligation to
                 update, debug, and/or continue to support the Software. Any use of the Software is at your own risk.
             </p>
         </div>
@@ -25,34 +26,36 @@
                 User Data
             </h4>
             <p>
-                You are running the Software in a web browser on your device. 
-                All application data is saved locally within this browser to your device and/or browser. 
-                NREL, ORNL, and the DOE do not have access to data you input into the Software and/or outputs 
-                based on your data provided by the Software. 
-                Should the Software, your browser, and/or your device crash, fail, or otherwise have an error, 
-                data you entered into the Software and the outputs based on that data may be lost. 
-                It is encouraged that you download backup files of your data frequently. 
-                Backups can be imported back into the Software if needed to restore lost or corrupted data. 
+                You are running the Software in a web browser on your device.
+                All application data is saved locally within this browser to your device and/or browser.
+                NREL, ORNL, and the DOE do not have access to data you input into the Software and/or outputs
+                based on your data provided by the Software.
+                Should the Software, your browser, and/or your device crash, fail, or otherwise have an error,
+                data you entered into the Software and the outputs based on that data may be lost.
+                It is encouraged that you download backup files of your data frequently.
+                Backups can be imported back into the Software if needed to restore lost or corrupted data.
             </p>
             <p>
-                You may voluntarily provide a backup file of your data to ORNL and NREL for use in improving the Software. 
-                By providing such data you are agreeing that ORNL and NREL may use such data without restriction and without 
-                compensation or obligation to you. 
-                To the extent any license would be required to utilize such data, you automatically grant ORNL and NREL, 
-                when submitting such data, a worldwide, royalty-free, perpetual, irrevocable, non-exclusive, 
+                You may voluntarily provide a backup file of your data to ORNL and NREL for use in improving the
+                Software.
+                By providing such data you are agreeing that ORNL and NREL may use such data without restriction and
+                without
+                compensation or obligation to you.
+                To the extent any license would be required to utilize such data, you automatically grant ORNL and NREL,
+                when submitting such data, a worldwide, royalty-free, perpetual, irrevocable, non-exclusive,
                 transferrable, and sublicensable license under any rights necessary for such use or implementation.
 
             </p>
             <p>
-                THIS SOFTWARE IS PROVIDED BY ORNL and NREL "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-                INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
-                FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
-                IN NO EVENT SHALL ORNL, NREL, OR CONTRIBUTORS BE LIABLE FOR 
-                ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES 
-                (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-                LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED 
-                AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, 
-                OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, 
+                THIS SOFTWARE IS PROVIDED BY ORNL and NREL "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+                INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+                FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+                IN NO EVENT SHALL ORNL, NREL, OR CONTRIBUTORS BE LIABLE FOR
+                ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+                (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+                LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+                AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+                OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
                 EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
             </p>
         </div>
@@ -71,43 +74,57 @@
             <p>OPEN SOURCE LICENSE (Permissive)</p>
 
             <p>
-                Subject to the conditions of this License, Alliance for Sustainable Energy, LLC 
-                and UT-Battelle, LLC (the "Licensors") hereby grant, free of charge, to any person (the "Licensee") 
-                obtaining a copy of this software and associated documentation files (the "Software"), a perpetual, 
-                worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to use, copy, modify, 
+                Subject to the conditions of this License, Alliance for Sustainable Energy, LLC
+                and UT-Battelle, LLC (the "Licensors") hereby grant, free of charge, to any person (the "Licensee")
+                obtaining a copy of this software and associated documentation files (the "Software"), a perpetual,
+                worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to use, copy, modify,
                 merge, publish, distribute, and/or sublicense copies of the Software.
             </p>
-            
+
             <p>
-                1. Redistributions of Software must retain the above open source license grant, copyright and license notices, 
-                this list of conditions, and the disclaimer listed below. Changes or modifications to, 
-                or derivative works of the Software must be noted with comments and the contributor and organization's name.
+                1. Redistributions of Software must retain the above open source license grant, copyright and license
+                notices,
+                this list of conditions, and the disclaimer listed below. Changes or modifications to,
+                or derivative works of the Software must be noted with comments and the contributor and organization's
+                name.
             </p>
-            
+
             <p>
-                2. Neither the names of Licensors, the Department of Energy, or their employees may be used 
-                to endorse or promote products derived from this Software without their specific prior written permission.
+                2. Neither the names of Licensors, the Department of Energy, or their employees may be used
+                to endorse or promote products derived from this Software without their specific prior written
+                permission.
             </p>
-            
+
             <p>
-                3. If the Software is protected by a proprietary trademark owned by either Licensor or 
-                the Department of Energy, then derivative works of the Software may not be distributed 
+                3. If the Software is protected by a proprietary trademark owned by either Licensor or
+                the Department of Energy, then derivative works of the Software may not be distributed
                 using the trademark without the prior written approval of the trademark owner.
             </p>
-            
+
             <hr>
 
             <p>
                 DISCLAIMER
-                ALLIANCE FOR SUSTAINABLE ENERGY, LLC, UT-BATTELLE, LLC AND THE GOVERNMENT MAKE NO REPRESENTATIONS 
-                AND DISCLAIM ALL WARRANTIES, BOTH EXPRESSED AND IMPLIED. THERE ARE NO EXPRESS OR IMPLIED WARRANTIES 
-                OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE, OR THAT THE USE OF THE SOFTWARE WILL NOT 
-                INFRINGE ANY PATENT, COPYRIGHT, TRADEMARK, OR OTHER PROPRIETARY RIGHTS, 
-                OR THAT THE SOFTWARE WILL ACCOMPLISH THE INTENDED RESULTS OR THAT THE SOFTWARE OR 
-                ITS USE WILL NOT RESULT IN INJURY OR DAMAGE. THE USER ASSUMES RESPONSIBILITY 
-                FOR ALL LIABILITIES, PENALTIES, FINES, CLAIMS, CAUSES OF ACTION, 
-                AND COSTS AND EXPENSES, CAUSED BY, RESULTING FROM OR ARISING OUT OF, IN WHOLE OR IN PART THE USE, 
+                ALLIANCE FOR SUSTAINABLE ENERGY, LLC, UT-BATTELLE, LLC AND THE GOVERNMENT MAKE NO REPRESENTATIONS
+                AND DISCLAIM ALL WARRANTIES, BOTH EXPRESSED AND IMPLIED. THERE ARE NO EXPRESS OR IMPLIED WARRANTIES
+                OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE, OR THAT THE USE OF THE SOFTWARE WILL NOT
+                INFRINGE ANY PATENT, COPYRIGHT, TRADEMARK, OR OTHER PROPRIETARY RIGHTS,
+                OR THAT THE SOFTWARE WILL ACCOMPLISH THE INTENDED RESULTS OR THAT THE SOFTWARE OR
+                ITS USE WILL NOT RESULT IN INJURY OR DAMAGE. THE USER ASSUMES RESPONSIBILITY
+                FOR ALL LIABILITIES, PENALTIES, FINES, CLAIMS, CAUSES OF ACTION,
+                AND COSTS AND EXPENSES, CAUSED BY, RESULTING FROM OR ARISING OUT OF, IN WHOLE OR IN PART THE USE,
                 STORAGE OR DISPOSAL OF THE SOFTWARE.
+            </p>
+            <p>
+                ****************************************************************************************************************
+                NOTICE TO USERS
+                Note that users should be aware that finding non-energy benefits can vary and are not guaranteed.
+                The use of the JUSTIFI tool does not constitute or imply any endorsement, recommendation,
+                or favoring of any entity, product, or service.
+                Please refer to the terms and disclaimer located in the project <a
+                    [href]="'https://github.com/ORNL-AMO/JUSTIFI/blob/master/LICENSE'" target="_blank">LICENSE</a> file
+                and in the application's documentation for more information.
+                ****************************************************************************************************************
             </p>
         </div>
     </div>


### PR DESCRIPTION
connects #131 

This pull request adds a new "Notice to Users" disclaimer to both the `LICENSE` file and the About page in the application's UI, clarifying that non-energy benefits are not guaranteed and that use of the JUSTIFI tool does not imply endorsement. It also makes minor formatting improvements to the About page for better readability.

**Legal and disclaimer updates:**

* Added a "Notice to Users" section to the end of the `LICENSE` file, clarifying that non-energy benefits are not guaranteed and that use of the JUSTIFI tool does not imply endorsement, recommendation, or favoring of any entity, product, or service.
* Added the same "Notice to Users" disclaimer to the About page (`about.component.html`), including a link to the LICENSE file for further information.

**UI and content formatting improvements:**

* Improved line breaks and paragraph formatting in the About page to enhance readability, including splitting long lines and improving clarity in the backup data section. [[1]](diffhunk://#diff-3aeec1425e6cc00273c91a78206cdb97a4d89d73e4735f363f4e230986c4f877L10-R11) [[2]](diffhunk://#diff-3aeec1425e6cc00273c91a78206cdb97a4d89d73e4735f363f4e230986c4f877L38-R42)
* Reformatted license and disclaimer information in the About page for consistency and easier reading, including clearer presentation of redistribution and endorsement conditions.