### PR TITLE
ci/bump-macos-14 - Update release_desktop bundle_macos job to MacOS 14 runner

### DIFF
--- a/.github/workflows/release_desktop.yml
+++ b/.github/workflows/release_desktop.yml
@@ -51,7 +51,7 @@ jobs:
 
   bundle_macos:
     if: github.ref_name == 'master'
-    runs-on: macos-13
+    runs-on: macos-14
     needs: [build]
     steps:
       - name: Checkout


### PR DESCRIPTION
Changes:
  - Bump bundle_macos 'runs_on' target to MacOS 14 as 13 is deprecated. No other changes required for this bundle and signing process