### PR TITLE
Issue 169: fix payback calculation so it isn't negative

### DIFF
--- a/src/app/shared/reports/calculations/assessmentReport.ts
+++ b/src/app/shared/reports/calculations/assessmentReport.ts
@@ -163,11 +163,11 @@ export function getAssessmentReport(
     }) + totalNonOpportunityRebates;
 
     let totalPaybackWithNebs: number = ((implementationCost - totalRebates) / totalFinancialImpact);
-    if (totalPaybackWithNebs == Infinity) {
+    if (totalPaybackWithNebs == Infinity || isNaN(totalPaybackWithNebs) || totalPaybackWithNebs < 0) {
         totalPaybackWithNebs = 0;
     }
     let totalPaybackWithoutNebs: number = (implementationCost / totalNonNebCostSavings);
-    if (totalPaybackWithoutNebs == Infinity) {
+    if (totalPaybackWithoutNebs == Infinity || isNaN(totalPaybackWithoutNebs) || totalPaybackWithoutNebs < 0) {
         totalPaybackWithoutNebs = 0;
     }
 
@@ -178,11 +178,11 @@ export function getAssessmentReport(
     }
 
     let nonOpportunityPaybackWithoutNebs: number = (assessment.implementationCost / assessment.costSavings);
-    if (nonOpportunityPaybackWithoutNebs == Infinity) {
+    if (nonOpportunityPaybackWithoutNebs == Infinity || isNaN(nonOpportunityPaybackWithoutNebs) || nonOpportunityPaybackWithoutNebs < 0) {
         nonOpportunityPaybackWithoutNebs = 0;
     }
     let nonOpportunityPaybackWithNebs: number = ((assessment.implementationCost - totalNonOpportunityRebates) / totalNonOpportunityCostSavings);
-    if (nonOpportunityPaybackWithNebs == Infinity) {
+    if (nonOpportunityPaybackWithNebs == Infinity || isNaN(nonOpportunityPaybackWithNebs) || nonOpportunityPaybackWithNebs < 0) {
         nonOpportunityPaybackWithNebs = 0;
     }
 

--- a/src/app/shared/reports/calculations/energyOpportunityReport.ts
+++ b/src/app/shared/reports/calculations/energyOpportunityReport.ts
@@ -46,11 +46,11 @@ export function getEnergyOpportunityReport(
         return nebReport.totalRebates
     });
     let paybackWithNebs: number = ((energyOpportunity.implementationCost - totalRebates) / totalFinancialImpact);
-    if (paybackWithNebs == Infinity) {
+    if (paybackWithNebs == Infinity || isNaN(paybackWithNebs) || paybackWithNebs < 0) {
         paybackWithNebs = 0;
     }
     let paybackWithoutNebs: number = (energyOpportunity.implementationCost / totalNonNebCostSavings);
-    if (paybackWithoutNebs == Infinity) {
+    if (paybackWithoutNebs == Infinity || isNaN(paybackWithoutNebs) || paybackWithoutNebs < 0) {
         paybackWithoutNebs = 0;
     }
 

--- a/src/app/shared/reports/calculations/executiveSummaryReport.ts
+++ b/src/app/shared/reports/calculations/executiveSummaryReport.ts
@@ -103,11 +103,11 @@ export function getExecutiveSummaryReport(visitDate: Date, assessmentIds: Array<
     });
 
     let totalPaybackWithoutNebs: number = (totalImplementationCost / totalNonNebCostSavings);
-    if (totalPaybackWithoutNebs == Infinity || isNaN(totalPaybackWithoutNebs)) {
+    if (totalPaybackWithoutNebs == Infinity || isNaN(totalPaybackWithoutNebs) || totalPaybackWithoutNebs < 0) {
         totalPaybackWithoutNebs = 0;
     }
     let totalPaybackWithNebs: number = ((totalImplementationCost - totalRebates) / totalFinancialImpact);
-    if (totalPaybackWithNebs == Infinity || isNaN(totalPaybackWithNebs)) {
+    if (totalPaybackWithNebs == Infinity || isNaN(totalPaybackWithNebs) || totalPaybackWithNebs < 0) {
         totalPaybackWithNebs = 0;
     }
 

--- a/src/app/shared/reports/executive-summary-report/executive-summary-project-summary/executive-summary-project-summary.component.ts
+++ b/src/app/shared/reports/executive-summary-report/executive-summary-project-summary/executive-summary-project-summary.component.ts
@@ -127,11 +127,11 @@ export class ExecutiveSummaryProjectSummaryComponent {
     })
 
     let paybackWithNebs: number = (totalFinalImplementationCost / totalFinancialImpact);
-    if (paybackWithNebs == Infinity) {
+    if (paybackWithNebs == Infinity || paybackWithNebs < 0 || isNaN(paybackWithNebs)) {
       paybackWithNebs = 0;
     }
     let paybackWithoutNebs: number = (totalImplementationCost / totalNonNebCostSavings);
-    if (paybackWithoutNebs == Infinity) {
+    if (paybackWithoutNebs == Infinity || paybackWithoutNebs < 0 || isNaN(paybackWithoutNebs)) {
       paybackWithoutNebs = 0;
     }
     this.additionalReports = {


### PR DESCRIPTION
connects #169 

This pull request improves the robustness of payback calculations across several report generation functions by ensuring that invalid payback values (such as negative numbers or NaN) are set to zero, in addition to handling Infinity as before. This prevents misleading or erroneous payback results from appearing in reports.

**Improvements to payback calculation validation:**

* Updated payback calculations in `getAssessmentReport` (`assessmentReport.ts`) to set payback to zero if the result is Infinity, NaN, or negative. [[1]](diffhunk://#diff-05c9afedf71de5b0fbb9d7039702e3c843ed5bde6868d5452754bb9f353832b5L166-R170) [[2]](diffhunk://#diff-05c9afedf71de5b0fbb9d7039702e3c843ed5bde6868d5452754bb9f353832b5L181-R185)
* Applied the same validation logic to payback calculations in `getEnergyOpportunityReport` (`energyOpportunityReport.ts`).
* Enhanced payback validation in `getExecutiveSummaryReport` (`executiveSummaryReport.ts`) to include checks for negative and NaN values.
* Updated the `ExecutiveSummaryProjectSummaryComponent` to ensure payback values are set to zero if they are Infinity, negative, or NaN.