### PR TITLE
Issue 171: fix bug setting impact on KPM to undefined on baseline changes

### DIFF
--- a/src/app/shared/shared-assessment-forms/neb-forms-accordion/neb-setup-form/performance-metric-impact-form/performance-metric-impact-form.component.ts
+++ b/src/app/shared/shared-assessment-forms/neb-forms-accordion/neb-setup-form/performance-metric-impact-form/performance-metric-impact-form.component.ts
@@ -109,7 +109,6 @@ export class PerformanceMetricImpactFormComponent {
 
   async calculateCostFromKPM(kpmChanges: { modifiedMethod: boolean, updateBaseline: boolean }) {
     if (kpmChanges.modifiedMethod) {
-      this.keyPerformanceMetricImpact.modificationValue = undefined;
       if (this.keyPerformanceMetricImpact.calculationMethod == 'costPerUnit' && this.keyPerformanceMetric.calculationMethod != 'costPerUnit') {
         this.keyPerformanceMetricImpact.calculationMethod = 'directCost';
       }
@@ -126,7 +125,6 @@ export class PerformanceMetricImpactFormComponent {
     } else if (this.keyPerformanceMetricImpact.calculationMethod == 'directCost') {
       this.keyPerformanceMetricImpact.costAdjustment = this.keyPerformanceMetricImpact.modificationValue;
     }
-    console.log('calcCost...')
     if (this.keyPerformanceMetric.isQuantitative == false) {
       if (this.keyPerformanceMetric.goalToIncrease) {
         this.keyPerformanceMetricImpact.modifiedValue = this.keyPerformanceMetric.baselineValue + this.keyPerformanceMetricImpact.modificationValue;
@@ -134,7 +132,6 @@ export class PerformanceMetricImpactFormComponent {
         this.keyPerformanceMetricImpact.modifiedValue = this.keyPerformanceMetric.baselineValue - this.keyPerformanceMetricImpact.modificationValue;
       }
     }
-    console.log(this.keyPerformanceMetricImpact.modifiedValue)
     await this.saveChanges();
   }
 


### PR DESCRIPTION
connects #171 

Update logic so that modification value is not cleared out when changes are made to baseline when in KPM impacts form.