### PR TITLE
Issue 168: remove link to beta survey

### DIFF
--- a/src/app/core-components/feedback-page/feedback-page.component.html
+++ b/src/app/core-components/feedback-page/feedback-page.component.html
@@ -20,11 +20,6 @@
                 <li>Send an email with subject line: <span class="bold">“JUSTIFI Feedback - A Summary”</span></li>
                 <li>The team may follow up with you for clarification and updates.</li>
             </ul>
-            <p>
-                <span class="bold">Prefer a survey?</span> Complete our
-                <a href="https://forms.office.com/g/mBL1Rvp9cP" target="_blank">Feedback Survey</a>
-                to share your impressions, experiences, and suggestions.
-            </p>
             <hr>
             <h5>
                 <fa-icon [icon]="faBug" class="pe-1"></fa-icon> Bug Reporting


### PR DESCRIPTION
connects #168 

Removed the old link to the microsoft forms survey we had for beta. A new survey will be embedded in the application at a later time in the connected issue