### PR TITLE
chore: remove emissions from MB database

### DIFF
--- a/src/app/shared/constants/keyPerformanceMetrics.ts
+++ b/src/app/shared/constants/keyPerformanceMetrics.ts
@@ -102,13 +102,9 @@ export type KeyPerformanceMetricValue =
     'rawMaterials' |
     'intermediateGoods' |
     'custom' |
-    'stationaryFuelEmissions' |
-    'purchasedEnergyEmissions' |
-    'valueChainEmissions' |
     'regulatoryCompliancePercentTests' |
     'noxSoxCoEmissions' |
     'particulateEmissions' |
-    'waterPollutantEmissions' |
     'sewageCosts' | 
     'regulatoryFeesWater' | 
     'regulatoryFeesWaste' | 
@@ -116,8 +112,6 @@ export type KeyPerformanceMetricValue =
     'emergencyEquipmentDowntime' |
     'electricalDemandCosts' |
     'powerFactorCosts' |
-    'mobileFuelEmissions'|
-    'processEmissions' |
     'reduceRegulatoryFees' | 
     'utilityCosts';
 
@@ -551,8 +545,8 @@ export const KeyPerformanceMetricOptions: Array<KeyPerformanceMetricOption> = [
         calculationMethod: 'directCost'
     },
     {
-        label: "Dust Emissions",
-        htmlLabel: "Dust Emissions",
+        label: "Dust Discharge",
+        htmlLabel: "Dust Discharge",
         value: "dustEmission",
         kpiValue: "airEnvironmentalQuality",
         isQuantitative: true,
@@ -562,41 +556,8 @@ export const KeyPerformanceMetricOptions: Array<KeyPerformanceMetricOption> = [
         calculationMethod: 'percentTotal'
     },
     {
-        label: "Stationary Fuel Emissions",
-        htmlLabel: "Stationary Fuel Emissions",
-        value: "stationaryFuelEmissions",
-        kpiValue: "airEnvironmentalQuality",
-        isQuantitative: true,
-        goalToIncrease: false,
-        totalUnit: 'tonne CO2e',
-        timePeriod: 'yr',
-        calculationMethod: 'costPerUnit'
-    },
-    {
-        label: "Purchased Energy Emissions",
-        htmlLabel: "Purchased Energy Emissions",
-        value: "purchasedEnergyEmissions",
-        kpiValue: "airEnvironmentalQuality",
-        totalUnit: 'tonne CO2e',
-        isQuantitative: true,
-        goalToIncrease: false,
-        timePeriod: 'yr',
-        calculationMethod: 'costPerUnit'
-    },
-    {
-        label: "Value Chain Emissions",
-        htmlLabel: "Value Chain Emissions",
-        value: "valueChainEmissions",
-        kpiValue: "airEnvironmentalQuality",
-        totalUnit: 'tonne CO2e',
-        isQuantitative: true,
-        goalToIncrease: false,
-        timePeriod: 'yr',
-        calculationMethod: 'costPerUnit'
-    },
-    {
-        label: "Particulate Emissions",
-        htmlLabel: "Particulate Emissions",
+        label: "Particulate Release",
+        htmlLabel: "Particulate Release",
         value: "particulateEmissions",
         kpiValue: "airEnvironmentalQuality",
         isQuantitative: true,
@@ -605,8 +566,8 @@ export const KeyPerformanceMetricOptions: Array<KeyPerformanceMetricOption> = [
         calculationMethod: 'percentTotal'
     },
     {
-        label: "NOx, SOx, CO Emissions",
-        htmlLabel: "NOx, SOx, CO Emissions",
+        label: "NOx, SOx, CO Release",
+        htmlLabel: "NOx, SOx, CO Release",
         value: "noxSoxCoEmissions",
         kpiValue: "airEnvironmentalQuality",
         isQuantitative: true,
@@ -618,26 +579,6 @@ export const KeyPerformanceMetricOptions: Array<KeyPerformanceMetricOption> = [
         label: "Regulatory Compliance (% tests)",
         htmlLabel: "Regulatory Compliance (&#37; tests)",
         value: "regulatoryCompliancePercentTests",
-        kpiValue: "airEnvironmentalQuality",
-        isQuantitative: true,
-        goalToIncrease: false,
-        timePeriod: 'yr',
-        calculationMethod: 'percentTotal'
-    },
-    {
-        label: "Water Pollutant Emissions",
-        htmlLabel: "Water Pollutant Emissions",
-        value: "waterPollutantEmissions",
-        kpiValue: "waterConsumption",
-        isQuantitative: true,
-        goalToIncrease: false,
-        timePeriod: 'yr',
-        calculationMethod: 'percentTotal'
-    },
-    {
-        label: "Refrigerant Emissions",
-        htmlLabel: "Refrigerant Emissions",
-        value: "percentOrTotalRefrigerantEmissions",
         kpiValue: "airEnvironmentalQuality",
         isQuantitative: true,
         goalToIncrease: false,
@@ -968,28 +909,6 @@ export const KeyPerformanceMetricOptions: Array<KeyPerformanceMetricOption> = [
         calculationMethod: 'directCost'
     },
     {
-        label: "Mobile Fuel Emissions",
-        htmlLabel: "Mobile Fuel Emissions",
-        value: "mobileFuelEmissions",
-        kpiValue: "airEnvironmentalQuality",
-        isQuantitative: true,
-        totalUnit: 'tonne CO2e',
-        goalToIncrease: false,
-        timePeriod: 'yr',
-        calculationMethod: 'costPerUnit'
-    },
-    {
-        label: "Process Emissions",
-        htmlLabel: "Process Emissions",
-        value: "processEmissions",
-        kpiValue: "airEnvironmentalQuality",
-        isQuantitative: true,
-        totalUnit: 'tonne CO2e',
-        goalToIncrease: false,
-        timePeriod: 'yr',
-        calculationMethod: 'costPerUnit'
-    },
-    {
         label: "Reduce Regulatory Fees",
         htmlLabel: "Reduce Regulatory Fees",
         value: "reduceRegulatoryFees",
@@ -1040,7 +959,6 @@ const KpmKeywords: { [key: string]: Array<string> } = {
     "percentTotalOrCost": ["total cost", "cost percentage", "overall cost", "cost analysis"],
     "consumptionCostWater": ["water consumption cost", "water usage cost", "water expense", "water bill"],
     "sewageVolume": ["sewage volume", "wastewater volume", "sewage management", "wastewater treatment"],
-    "percentOrTotalRefrigerantEmissions": ["refrigerant emissions", "refrigerant leakage", "refrigerant management", "cooling emissions"],
     "TRIR": ["TRIR", "total recordable incident rate", "safety incidents", "workplace safety"],
     "oshaRecordableIncidents": ["OSHA recordable incidents", "workplace incidents", "safety compliance", "incident reporting"],
     "oshaNonRecordables": ["OSHA non-recordables", "non-recordable incidents", "safety near misses", "incident prevention"],
@@ -1060,13 +978,9 @@ const KpmKeywords: { [key: string]: Array<string> } = {
     "rawMaterials": ["raw materials", "material costs", "supply chain", "material procurement"],
     "intermediateGoods": ["intermediate goods", "semi-finished products", "supply chain management", "goods in process"],
     "custom": ["custom metrics", "custom KPIs", "tailored metrics", "bespoke performance indicators"],
-    "stationaryFuelEmissions": ["stationary fuel emissions", "fuel consumption", "energy emissions", "stationary sources"],
-    "purchasedEnergyEmissions": ["purchased energy emissions", "energy procurement", "energy consumption", "external energy sources"],
-    "valueChainEmissions": ["value chain emissions", "supply chain emissions", "indirect emissions", "life cycle emissions"],
     "regulatoryCompliancePercentTests": ["regulatory compliance", "compliance testing", "environmental regulations", "regulatory standards"],
     "noxSoxCoEmissions": ["NOx emissions", "SOx emissions", "CO emissions", "air pollutants"],
     "particulateEmissions": ["particulate emissions", "air quality", "dust emissions", "particulate matter"],
-    "waterPollutantEmissions": ["water pollutant emissions", "water quality", "pollution control", "water management"],
     'sewageCosts': ["sewage costs", "wastewater costs", "sewage management", "wastewater treatment"],
     'regulatoryFeesWater': ["regulatory fees water", "water compliance costs", "water regulatory fees", "water management costs"],
     'regulatoryFeesWaste': ["regulatory fees waste", "waste compliance costs", "waste regulatory fees", "waste management costs"],
@@ -1074,8 +988,6 @@ const KpmKeywords: { [key: string]: Array<string> } = {
     'emergencyEquipmentDowntime': ["emergency equipment downtime", "unplanned downtime", "equipment failure", "maintenance issues"],
     'electricalDemandCosts': ["electrical demand costs", "energy demand charges", "power demand costs", "electricity expenses"],
     'powerFactorCosts': ["power factor costs", "power factor penalties", "electricity efficiency", "power quality"],
-    'mobileFuelEmissions': ["mobile fuel emissions", "transport emissions", "vehicle emissions", "mobile sources"],
-    'processEmissions': ["process emissions", "industrial emissions", "manufacturing emissions", "production emissions", "process pollutants"],
     'reduceRegulatoryFees': ["reduce regulatory fees", "regulatory cost reduction", "compliance cost savings", "regulatory fee management"],
     'utilityCosts': ["utility costs", "energy expenses", "utility bills", "electricity costs"],
 }

--- a/src/app/shared/constants/nonEnergyBenefitOptions.ts
+++ b/src/app/shared/constants/nonEnergyBenefitOptions.ts
@@ -37,8 +37,6 @@ export type NebOptionValue = 'improvedImageOrReputation' |
     'reduceWaterConsumption' |
     'reduceSewageVolume' |
     'reduceDustEmissions' |
-    'reduceChemicalEmissions' |
-    'reduceRefrigerantGasEmissions' |
     'reduceOccupationalDangers' |
     'reducedNoiseExposure' |
     'improveAmbientAirQuality' |
@@ -156,7 +154,7 @@ export const NebOptions: Array<NebOption> = [
         optionValue: "reduceIndustrialTrucksDowntime",
         isQualitative: true,
         howToCalculate: "N/A",
-        KPM: ["equipmentDowntime", "percentCapacityUtilization", "overallEquipmentEffectiveness", "forkTruckBreakdownTime", "maintenanceCost", "employeeEngagementSatisfaction", "laborCosts", "equipmentDowntime", "mobileFuelEmissions"],
+        KPM: ["equipmentDowntime", "percentCapacityUtilization", "overallEquipmentEffectiveness", "forkTruckBreakdownTime", "maintenanceCost", "employeeEngagementSatisfaction", "laborCosts", "equipmentDowntime"],
         selectedKPM: []
     },
     {
@@ -300,7 +298,7 @@ export const NebOptions: Array<NebOption> = [
         optionValue: "reduceProductWaste",
         isQualitative: true,
         howToCalculate: "N/A",
-        KPM: ["contributeCompanyVision", "defectiveProductionDollar", "defectRatePPMorDPM", "percentShrinkage", "percentTotalOrCost", "processEmissions"],
+        KPM: ["contributeCompanyVision", "defectiveProductionDollar", "defectRatePPMorDPM", "percentShrinkage", "percentTotalOrCost"],
         selectedKPM: []
     },
     {
@@ -322,21 +320,12 @@ export const NebOptions: Array<NebOption> = [
         selectedKPM: []
     },
     {
-        label: "Reduce dust emission",
-        htmlLabel: "Reduce dust emissions",
+        label: "Reduce dust discharge",
+        htmlLabel: "Reduce dust discharge",
         optionValue: "reduceDustEmissions",
         isQualitative: true,
         howToCalculate: "N/A",
         KPM: ["contributeCompanyVision", "dustEmission", "particulateEmissions"],
-        selectedKPM: []
-    },
-    {
-        label: "Reduce refrigerant gas emissions",
-        htmlLabel: "Reduce refrigerant gas emissions",
-        optionValue: "reduceRefrigerantGasEmissions",
-        isQualitative: true,
-        howToCalculate: "N/A",
-        KPM: ["contributeCompanyVision", "percentOrTotalRefrigerantEmissions"],
         selectedKPM: []
     },
     {
@@ -511,21 +500,12 @@ export const NebOptions: Array<NebOption> = [
         selectedKPM: []
     },
     {
-        label: "Reduce GHG emissions",
-        htmlLabel: "Reduce GHG emissions",
-        optionValue: "reduceChemicalEmissions",
-        isQualitative: true,
-        howToCalculate: "N/A",
-        KPM: ["stationaryFuelEmissions", "purchasedEnergyEmissions", "valueChainEmissions", "mobileFuelEmissions", "processEmissions"],
-        selectedKPM: []
-    },
-    {
         label: "Reduce regulatory costs",
         htmlLabel: "Reduce regulatory costs",
         optionValue: "reduceRegulatoryCosts",
         isQualitative: true,
         howToCalculate: "N/A",
-        KPM: ["stationaryFuelEmissions", "purchasedEnergyEmissions", "valueChainEmissions", "particulateEmissions", "noxSoxCoEmissions", "regulatoryCompliancePercentTests", "waterPollutantEmissions", "reduceRegulatoryFees"],
+        KPM: ["particulateEmissions", "noxSoxCoEmissions", "regulatoryCompliancePercentTests", "reduceRegulatoryFees"],
         selectedKPM: []
     },
     {
@@ -534,7 +514,7 @@ export const NebOptions: Array<NebOption> = [
         optionValue: "improvedWaterQuality",
         isQualitative: true,
         howToCalculate: "N/A",
-        KPM: ["waterPollutantEmissions"],
+        KPM: [],
         selectedKPM: []
     },
     {
@@ -754,7 +734,7 @@ export const NebKeywords: { [key: string]: Array<string>} = {
     
         // Synonyms and related terms
         "reduce toxic waste", "hazardous material reduction", "minimize toxic materials", "reduce hazardous byproducts",
-        "hazardous waste management", "toxic waste disposal", "reduce hazardous emissions", "improve hazardous waste handling"
+        "hazardous waste management", "toxic waste disposal", "improve hazardous waste handling"
     ],
     reduceNonhazardousWaste: [
         // Keywords from the NEB label
@@ -762,7 +742,7 @@ export const NebKeywords: { [key: string]: Array<string>} = {
     
         // Synonyms and related terms
         "reduce general waste", "nonhazardous material reduction", "minimize general waste", "reduce nonhazardous byproducts",
-        "nonhazardous waste management", "general waste disposal", "reduce nonhazardous emissions", "improve nonhazardous waste handling"
+        "nonhazardous waste management", "general waste disposal", "improve nonhazardous waste handling"
     ],
     reduceProductWaste: [
         // Keywords from the NEB label
@@ -791,20 +771,11 @@ export const NebKeywords: { [key: string]: Array<string>} = {
     ],
     reduceDustEmissions: [
         // Keywords from the NEB label
-        "reduce dust emissions", "dust emissions reduction", "minimize dust emissions", "dust control",
+        "reduce dust discharge", "dust discharge reduction", "minimize dust discharge", "dust control",
     
         // Synonyms and related terms
-        "reduce particulate emissions", "dust suppression", "airborne dust reduction", "dust mitigation",
+        "reduce particulate release", "dust suppression", "airborne dust reduction", "dust mitigation",
         "improve air quality", "reduce particulate matter", "dust pollution control", "dust abatement"
-    ],
-    reduceRefrigerantGasEmissions: [
-        // Keywords from the NEB label
-        "reduce refrigerant gas emissions", "refrigerant gas emissions reduction", "minimize refrigerant emissions",
-    
-        // Synonyms and related terms
-        "reduce refrigerant leaks", "refrigerant emissions control", "reduce greenhouse gas emissions",
-        "minimize refrigerant gas release", "reduce HVAC emissions", "reduce cooling system emissions",
-        "refrigerant management", "reduce fluorinated gas emissions", "reduce F-gas emissions"
     ],
     reduceOccupationalDangers: [
         // Keywords from the NEB label
@@ -856,8 +827,8 @@ export const NebKeywords: { [key: string]: Array<string>} = {
     
         // Synonyms and related terms
         "reduce air pollution", "reduce particulate matter", "reduce airborne contaminants", "cleaner air",
-        "reduce dust and emissions", "improve environmental air quality", "reduce atmospheric pollutants",
-        "enhance breathable air", "reduce harmful emissions", "improve ambient air conditions"
+        "reduce dust", "improve environmental air quality", "reduce atmospheric pollutants",
+        "enhance breathable air", "improve ambient air conditions"
     ],
     reducePPE: [
         // Keywords from the NEB label
@@ -973,15 +944,6 @@ export const NebKeywords: { [key: string]: Array<string>} = {
         // Synonyms and related terms
         "improve employee retention", "reduce workforce attrition", "minimize employee churn", "enhance workforce stability",
         "reduce talent turnover", "improve employee loyalty", "increase workforce retention", "reduce employee attrition"
-    ],
-    reduceChemicalEmissions: [
-        // Keywords from the NEB label
-        "reduce GHG emissions", "GHG emissions reduction", "minimize greenhouse gas emissions", "reduce greenhouse gases",
-    
-        // Synonyms and related terms
-        "reduce carbon emissions", "reduce CO2 emissions", "lower carbon footprint", "reduce methane emissions",
-        "reduce nitrous oxide emissions", "reduce fluorinated gas emissions", "reduce climate pollutants",
-        "reduce atmospheric emissions", "reduce harmful emissions", "reduce industrial emissions"
     ],
     reduceRegulatoryCosts: [
         // Keywords from the NEB label


### PR DESCRIPTION
connects #188 

This pull request makes significant changes to the key performance metrics and non-energy benefit options, primarily focusing on removing several emissions-related metrics and options, updating terminology for air quality metrics, and simplifying related keyword lists. These changes streamline the codebase and clarify the available metrics and options for both performance tracking and non-energy benefits.

**Key Performance Metrics Updates**

* Removed multiple emissions-related metric values from the `KeyPerformanceMetricValue` type, including stationary fuel, purchased energy, value chain, water pollutant, mobile fuel, process, and refrigerant emissions.
* Deleted corresponding emissions-related metric options from `KeyPerformanceMetricOptions`, including stationary fuel, purchased energy, value chain, water pollutant, mobile fuel, process, and refrigerant emissions. [[1]](diffhunk://#diff-d6284f99d24faed5a15a893dc8e0ad343c05c4b63791768104eeadb0b3212953L565-R560) [[2]](diffhunk://#diff-d6284f99d24faed5a15a893dc8e0ad343c05c4b63791768104eeadb0b3212953L627-L646) [[3]](diffhunk://#diff-d6284f99d24faed5a15a893dc8e0ad343c05c4b63791768104eeadb0b3212953L970-L991)
* Updated terminology to use "dust discharge," "particulate release," and "NOx, SOx, CO release" instead of "emissions" for relevant metrics. [[1]](diffhunk://#diff-d6284f99d24faed5a15a893dc8e0ad343c05c4b63791768104eeadb0b3212953L554-R549) [[2]](diffhunk://#diff-d6284f99d24faed5a15a893dc8e0ad343c05c4b63791768104eeadb0b3212953L565-R560) [[3]](diffhunk://#diff-d6284f99d24faed5a15a893dc8e0ad343c05c4b63791768104eeadb0b3212953L608-R570)
* Removed keywords associated with deleted metric values from `KpmKeywords`. [[1]](diffhunk://#diff-d6284f99d24faed5a15a893dc8e0ad343c05c4b63791768104eeadb0b3212953L1043) [[2]](diffhunk://#diff-d6284f99d24faed5a15a893dc8e0ad343c05c4b63791768104eeadb0b3212953L1063-L1078)

**Non-Energy Benefit Options Updates**

* Removed several emissions-related option values from `NebOptionValue`, including chemical and refrigerant gas emissions.
* Deleted corresponding NEB options for reducing refrigerant gas and chemical emissions, and removed references to deleted KPMs in other NEB options. [[1]](diffhunk://#diff-8a2a14699595bf18e9d371c184bd07a4648535b47ced0eef54e6d1cebb6ea029L159-R157) [[2]](diffhunk://#diff-8a2a14699595bf18e9d371c184bd07a4648535b47ced0eef54e6d1cebb6ea029L303-R301) [[3]](diffhunk://#diff-8a2a14699595bf18e9d371c184bd07a4648535b47ced0eef54e6d1cebb6ea029L325-L341) [[4]](diffhunk://#diff-8a2a14699595bf18e9d371c184bd07a4648535b47ced0eef54e6d1cebb6ea029L513-R508) [[5]](diffhunk://#diff-8a2a14699595bf18e9d371c184bd07a4648535b47ced0eef54e6d1cebb6ea029L537-R517)
* Updated terminology in NEB options to use "dust discharge" instead of "dust emission."

**Keyword List Simplification**

* Removed emission-related keywords from NEB keyword lists, including those for chemical and refrigerant gas emissions, and updated dust-related keywords to match new terminology. [[1]](diffhunk://#diff-8a2a14699595bf18e9d371c184bd07a4648535b47ced0eef54e6d1cebb6ea029L757-R745) [[2]](diffhunk://#diff-8a2a14699595bf18e9d371c184bd07a4648535b47ced0eef54e6d1cebb6ea029L794-L808) [[3]](diffhunk://#diff-8a2a14699595bf18e9d371c184bd07a4648535b47ced0eef54e6d1cebb6ea029L859-R831) [[4]](diffhunk://#diff-8a2a14699595bf18e9d371c184bd07a4648535b47ced0eef54e6d1cebb6ea029L977-L985)